### PR TITLE
How to make Vue router work with single-spa

### DIFF
--- a/docs/ecosystem-vue.md
+++ b/docs/ecosystem-vue.md
@@ -39,6 +39,15 @@ export const unmount = [
 ];
 ```
 
+## Routing
+In order for Vue router to work with Single-Spa's routing, it needs to be in `history` mode, not in `#` hash mode which is the default.  
+```
+const router = new Router({
+  mode: 'history',
+  routes,
+});
+```
+
 ## Options
 
 All options are passed to single-spa-vue via the `opts` parameter when calling `singleSpaVue(opts)`. The following options are available:


### PR DESCRIPTION
None of single-spa's examples or documentation attempt to use Vue's router.  If they did, users would know that in order to use the router with single-spa, it needs to be in "history" mode so as not to conflict with single-spa's hash based routing.