### PR TITLE
Lock down babel-loader to version 7

### DIFF
--- a/docs/starting-from-scratch.md
+++ b/docs/starting-from-scratch.md
@@ -82,7 +82,7 @@ yarn add clean-webpack-plugin --dev
 *Webpack Loaders*
 
 ```bash
-yarn add style-loader css-loader html-loader babel-loader --dev
+yarn add style-loader css-loader html-loader babel-loader@7 --dev
 ```
 
 * [html-Loader](https://webpack.js.org/loaders/html-loader/)


### PR DESCRIPTION
The latest babel-loader (v8.x) depends on babel v7.x which has breaking changes with the rest of the dependencies in the example. Lock down babel-loader version to 7.x to keep the example working.