### PR TITLE
Correct the bower package name in bower

### DIFF
--- a/docs/ecosystem-ember.md
+++ b/docs/ecosystem-ember.md
@@ -68,7 +68,7 @@ For the most part, you can get applications that use [ember cli](https://ember-c
 First, since the ember cli only supports dependencies from bower, you'll need to do:
 
 - `bower init`
-- `bower install single-spa-examples --save`
+- `bower install single-spa-ember --save`
 
 Add the following options to your ember-cli-build.js file:
 ```js


### PR DESCRIPTION
It's single-spa-ember, not single-spa-examples, correct it in the spa ember example.