### PR TITLE
fix twitter url in footer

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -64,7 +64,7 @@ class Footer extends React.Component {
               Stack Overflow
             </a>
             <a href="https://join.slack.com/t/single-spa/shared_invite/enQtMzIwMTcxNTU3ODQyLTM1Y2U1OWMzNTNjOWYyZDBlMDJhN2VkYzk3MDI2NzQ2Nzg0MzMzNjVhNWE2YjVhMTcxNjFkOWYzMjllMmUxMjk" target='_blank' rel='noopener'>Chat in Slack</a>
-            <a href="https://twitter.com/" target="_blank" rel='noopener'>
+            <a href="https://twitter.com/Single_spa/" target="_blank" rel='noopener'>
               Twitter
             </a>
           </div>


### PR DESCRIPTION
Twitter Link on the footer of https://single-spa.js.org/ was leading to https://twitter.com/ which was supposed to be https://twitter.com/Single_spa/
Fixed twitter link in footer code.