### PR TITLE
Fixing build by upgrading node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   deploy-website:
     docker:
       # specify the version you desire here
-      - image: circleci/node:8.11.1
+      - image: circleci/node:12.13.1
     steps:
       - checkout
       - run:


### PR DESCRIPTION
See error message in https://circleci.com/gh/CanopyTax/single-spa.js.org/378. We need to be using a version of node >=8.12