### PR TITLE
Fixing typo in Angular docs, as well as list on FAQ page.

### DIFF
--- a/docs/ecosystem-angular.md
+++ b/docs/ecosystem-angular.md
@@ -171,7 +171,7 @@ Example Configuration:
 ```
 
 ##### ng build options
-Configuration options are provided to the `architect.build.options` section of your angular.json. 
+Configuration options are provided to the `architect.build.options` section of your angular.json.
 
 | Name | Description | Default Value |
 | ---- | ----------- | ------------- |
@@ -180,7 +180,7 @@ Configuration options are provided to the `architect.build.options` section of y
 | singleSpaWebpackConfigPath | (optional) Path to partial webpack config to be merged with angular's config. Example: `extra-webpack.config.js` | undefined |
 
 ##### ng serve options
-Configuration options are provided to the `architect.serve.options` section of your angular.json. 
+Configuration options are provided to the `architect.serve.options` section of your angular.json.
 
 | Name | Description | Default Value |
 | ---- | ----------- | ------------- |
@@ -297,7 +297,7 @@ one instance of the ZoneJS library on the page. ZoneJS will throw errors if you 
 The preferred way to do ensure only one instance of ZoneJS is with an
 [import map](http://single-spa-playground.org/playground/html-file) and [webpack externals](https://webpack.js.org/configuration/externals/#root).
 Use the latest version of ZoneJS, even if your Angular applications use an older version. The latest version is backwards compatible all the
-way back to Angular 4 and will let you right new Angular applications with newer versions of Angular.
+way back to Angular 4 and will let you write new Angular applications with newer versions of Angular.
 
 If you have followed the installation instructions correctly, your code is already set up to do all of this.
 
@@ -319,7 +319,7 @@ If you did not use the `--prefix` option, you should set the prefix manually:
 2. Go to `app.component.ts`. Modify `selector` to be `app2-root`.
 3. Go to `main.single-spa.ts`. Modify `template` to be `<app2-root>`.
 
-Additionally, make sure that `reflect-metadata` is only imported once in the root application and is not imported again in the child applications. 
+Additionally, make sure that `reflect-metadata` is only imported once in the root application and is not imported again in the child applications.
 Otherwise, you might see an `No NgModule metadata found` error.
 See [issue thread](https://github.com/CanopyTax/single-spa-angular/issues/2#issuecomment-347864894) for more details.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -12,6 +12,7 @@ The applications can all be written in the same framework, or they can be implem
 
 ## Is there a recommended setup?
 We recommend a setup that uses in-browser ES modules + [import maps](#what-are-import-maps) (or [SystemJS](https://github.com/systemjs/systemjs) to polyfill these if you need better browser support).  This setup has several advantages:
+
 1. Common libraries are easy to manage, and are only downloaded once. If you're using SystemJS, you can also [preload them](https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content) for a speed boost as well.
 1. Sharing code / functions / variables is as easy as `import/export`, just like in a monolithic setup
 1. Lazy loading applications is easy, which enables you to speed up initial load times
@@ -104,7 +105,7 @@ Single spa supports code splits. There are so many ways to code split we won't b
     * For SystemJS >= 6, use [systemjs-webpack-interop](https://github.com/joeldenning/systemjs-webpack-interop):
     ```js
     import { setPublicPath } from 'systemjs-webpack-interop';
-    
+
     setPublicPath('name-of-module-in-import-map');
     ```
 

--- a/website/versioned_docs/version-4.x/ecosystem-angular.md
+++ b/website/versioned_docs/version-4.x/ecosystem-angular.md
@@ -171,7 +171,7 @@ Example Configuration:
 ```
 
 ##### ng build options
-Configuration options are provided to the `architect.build.options` section of your angular.json. 
+Configuration options are provided to the `architect.build.options` section of your angular.json.
 
 | Name | Description | Default Value |
 | ---- | ----------- | ------------- |
@@ -180,7 +180,7 @@ Configuration options are provided to the `architect.build.options` section of y
 | singleSpaWebpackConfigPath | (optional) Path to partial webpack config to be merged with angular's config. Example: `extra-webpack.config.js` | undefined |
 
 ##### ng serve options
-Configuration options are provided to the `architect.serve.options` section of your angular.json. 
+Configuration options are provided to the `architect.serve.options` section of your angular.json.
 
 | Name | Description | Default Value |
 | ---- | ----------- | ------------- |
@@ -297,7 +297,7 @@ one instance of the ZoneJS library on the page. ZoneJS will throw errors if you 
 The preferred way to do ensure only one instance of ZoneJS is with an
 [import map](http://single-spa-playground.org/playground/html-file) and [webpack externals](https://webpack.js.org/configuration/externals/#root).
 Use the latest version of ZoneJS, even if your Angular applications use an older version. The latest version is backwards compatible all the
-way back to Angular 4 and will let you right new Angular applications with newer versions of Angular.
+way back to Angular 4 and will let you write new Angular applications with newer versions of Angular.
 
 If you have followed the installation instructions correctly, your code is already set up to do all of this.
 
@@ -319,7 +319,7 @@ If you did not use the `--prefix` option, you should set the prefix manually:
 2. Go to `app.component.ts`. Modify `selector` to be `app2-root`.
 3. Go to `main.single-spa.ts`. Modify `template` to be `<app2-root>`.
 
-Additionally, make sure that `reflect-metadata` is only imported once in the root application and is not imported again in the child applications. 
+Additionally, make sure that `reflect-metadata` is only imported once in the root application and is not imported again in the child applications.
 Otherwise, you might see an `No NgModule metadata found` error.
 See [issue thread](https://github.com/CanopyTax/single-spa-angular/issues/2#issuecomment-347864894) for more details.
 

--- a/website/versioned_docs/version-4.x/faq.md
+++ b/website/versioned_docs/version-4.x/faq.md
@@ -12,6 +12,7 @@ The applications can all be written in the same framework, or they can be implem
 
 ## Is there a recommended setup?
 We recommend a setup that uses in-browser ES modules + [import maps](#what-are-import-maps) (or [SystemJS](https://github.com/systemjs/systemjs) to polyfill these if you need better browser support).  This setup has several advantages:
+
 1. Common libraries are easy to manage, and are only downloaded once. If you're using SystemJS, you can also [preload them](https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content) for a speed boost as well.
 1. Sharing code / functions / variables is as easy as `import/export`, just like in a monolithic setup
 1. Lazy loading applications is easy, which enables you to speed up initial load times
@@ -104,7 +105,7 @@ Single spa supports code splits. There are so many ways to code split we won't b
     * For SystemJS >= 6, use [systemjs-webpack-interop](https://github.com/joeldenning/systemjs-webpack-interop):
     ```js
     import { setPublicPath } from 'systemjs-webpack-interop';
-    
+
     setPublicPath('name-of-module-in-import-map');
     ```
 


### PR DESCRIPTION
Noticed the list on the second FAQ item was not rendering correctly. Fixed that, as well as a typo in the Angular docs.

**Before:**
![image](https://user-images.githubusercontent.com/412026/70666140-47ae5400-1c2b-11ea-8b28-5b868f1a07a9.png)

**After:**
![image](https://user-images.githubusercontent.com/412026/70666096-306f6680-1c2b-11ea-89ec-40fb040e4b4e.png)
