### PR TITLE
Fixing editUrl

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -128,7 +128,7 @@ module.exports = {
         docs: {
           path: '../docs',
           sidebarPath: require.resolve('./sidebars.json'),
-          editUrl: `${repoUrl}/blob/master/docs/`,
+          editUrl: `${repoUrl}/blob/master/website/`,
           // sidebarCollapsible: false,
         },
         theme: {


### PR DESCRIPTION
editUrl changed in docusaurus 2. See https://v2.docusaurus.io/docs/migrating-from-v1-to-v2/#customdocspath-docsurl-editurl-enableupdateby-enableupdatetime