### PR TITLE
Adding pages for recommended setup and microfrontends concept

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -11,13 +11,7 @@ The code for a route is called an "application", and each can (optionally) be in
 The applications can all be written in the same framework, or they can be implemented in different frameworks.
 
 ## Is there a recommended setup?
-We recommend a setup that uses in-browser ES modules + [import maps](#what-are-import-maps) (or [SystemJS](https://github.com/systemjs/systemjs) to polyfill these if you need better browser support).  This setup has several advantages:
-
-1. Common libraries are easy to manage, and are only downloaded once. If you're using SystemJS, you can also [preload them](https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content) for a speed boost as well.
-1. Sharing code / functions / variables is as easy as `import/export`, just like in a monolithic setup
-1. Lazy loading applications is easy, which enables you to speed up initial load times
-1. Each application (AKA microservice, AKA ES module) can be independently developed and deployed. Teams are enabled to work at their own speed, experiment (within reason as defined by the organization), QA, and deploy on thier own schedules. This usually also means that release cycles can be decreased to days instead of weeks or months
-1. A great developer experience (DX): go to your dev environment and add an import map that points the application's url to your localhost. See "[What is the DX like?](#what-is-the-developer-experience-dx-like)" for more details.
+Yes, here is [the documentation for our recommended setup](/docs/recommended-setup/).
 
 ## What is the impact to performance?
 When setup in the [recommended way](#is-there-a-recommended-setup), your code performance and bundle size will be nearly identical to a single application that has been code-split. The major differences will be the addition of the single-spa library (and SystemJS if you chose to use it). Other differences mainly come down to the difference between one (webpack / rollup / etc.) code bundle and in-browser ES modules.

--- a/docs/microfrontends-concept.md
+++ b/docs/microfrontends-concept.md
@@ -1,0 +1,9 @@
+---
+id: microfrontends-concept
+title: Microfrontends Overview
+sidebar_label: Overview
+---
+
+# Concept: Microfrontends
+
+[Tutorial video](https://www.youtube.com/watch?v=3EUfbnHi6Wg&list=PLLUD8RtHvsAOhtHnyGx57EYXoaNsxGrTU&index=1)

--- a/docs/recommended-setup.md
+++ b/docs/recommended-setup.md
@@ -6,6 +6,15 @@ sidebar_label: Overview
 
 Single-spa itself is not opinionated about your build tools, CI process, or local development workflow. However, to implement single-spa you will have to figure all of those things out (and more). To help you decide how to approach these problems, the single-spa core team has put together a "recommended setup" that gives an opinionated approach to solving the practical problems of microfrontends.
 
+## Overview
+We recommend a setup that uses in-browser ES modules + import maps (or SystemJS to polyfill these if you need better browser support). This setup has several advantages:
+
+1. Common libraries are easy to manage, and are only downloaded once. If you're using SystemJS, you can also preload them for a speed boost as well.
+2. Sharing code / functions / variables is as easy as import/export, just like in a monolithic setup
+3. Lazy loading applications is easy, which enables you to speed up initial load times
+4. Each application (AKA microservice, AKA ES module) can be independently developed and deployed. Teams are enabled to work at their own speed, experiment (within reason as defined by the organization), QA, and deploy on thier own schedules. This usually also means that release cycles can be decreased to days instead of weeks or months
+5. A great developer experience (DX): go to your dev environment and add an import map that points the application's url to your localhost. See sections below for details
+
 ## In-browser versus build-time modules
 [Tutorial video](https://www.youtube.com/watch?v=Jxqiu6pdMSU&list=PLLUD8RtHvsAOhtHnyGx57EYXoaNsxGrTU&index=2)
 

--- a/docs/recommended-setup.md
+++ b/docs/recommended-setup.md
@@ -1,0 +1,37 @@
+---
+id: recommended-setup
+title: The Recommended Setup
+sidebar_label: Overview
+---
+
+Single-spa itself is not opinionated about your build tools, CI process, or local development workflow. However, to implement single-spa you will have to figure all of those things out (and more). To help you decide how to approach these problems, the single-spa core team has put together a "recommended setup" that gives an opinionated approach to solving the practical problems of microfrontends.
+
+## In-browser versus build-time modules
+[Tutorial video](https://www.youtube.com/watch?v=Jxqiu6pdMSU&list=PLLUD8RtHvsAOhtHnyGx57EYXoaNsxGrTU&index=2)
+
+## Import Maps
+[Tutorial video](https://www.youtube.com/watch?v=Lfm2Ge_RUxs&list=PLLUD8RtHvsAOhtHnyGx57EYXoaNsxGrTU&index=3)
+
+## SystemJS
+
+## Lazy loading
+
+## Local development
+[Tutorial video](https://www.youtube.com/watch?v=vjjcuIxqIzY&list=PLLUD8RtHvsAOhtHnyGx57EYXoaNsxGrTU&index=4)
+
+## Build tools (Webpack / Rollup)
+
+## Utility modules (styleguide, API, etc)
+
+## Shared dependencies
+
+## Deployment
+[Tutorial video](https://www.youtube.com/watch?v=QHunH3MFPZs&list=PLLUD8RtHvsAOhtHnyGx57EYXoaNsxGrTU&index=5)
+
+## Continuous Integration (CI)
+
+## Applications versus parcels
+
+## Inter-app communication
+
+## State management

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -7,6 +7,9 @@
       "migrating-angularJS-tutorial"
     ],
     "Examples": ["examples"],
+    "Concept: Microfrontend": [
+      "microfrontends-concept"
+    ],
     "Concept: Root Config": ["configuration"],
     "Concept: Application": [
       "building-applications",
@@ -14,6 +17,9 @@
       "migrating-existing-spas"
     ],
     "Concept: Parcel": ["parcels-overview"],
+    "The Recommended Setup": [
+      "recommended-setup"
+    ],
     "API": ["api", "parcels-api"],
     "Ecosystem": [
       "ecosystem",


### PR DESCRIPTION
These pages are in the "next" version in docusaurus, which means you can only get to them by manually typing in the URL. I plan to release them as part of the single-spa@5 release.