### PR TITLE
Added example for multiple VM's and parcels

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -11,5 +11,6 @@ There are a variety of single-spa example repositories, each for different use c
 - [single-spa-es5-angularjs](https://github.com/joeldenning/single-spa-es5-angularjs) is a very tiny es5 example with angularjs.
 - [simple-single-spa-webpack-example](https://github.com/joeldenning/simple-single-spa-webpack-example) is a small, simple example that can be used as a webpack starter.
 - [demo-single-spa-with-spax](https://github.com/crossjs/spax/tree/master/packages/demo-single-spa) is a tiny [spax](https://spax.js.org) example with react-scripts and craco.
+- [single-spa-parcel-example](https://github.com/Guillembonet/single-spa-parcel-example) is an example of one vue and one react microfrontends, containing a react and a vue parcel respectively and two node.js microservices running in 6 different Docker VM's seamlessly working together in a single web app located in a 7th VM.
 
 Have your own starter repo? [Submit a PR](https://github.com/CanopyTax/single-spa.js.org/edit/master/docs/examples.md) to add yours to this list.

--- a/website/versioned_docs/version-4.x/examples.md
+++ b/website/versioned_docs/version-4.x/examples.md
@@ -11,5 +11,6 @@ There are a variety of single-spa example repositories, each for different use c
 - [single-spa-es5-angularjs](https://github.com/joeldenning/single-spa-es5-angularjs) is a very tiny es5 example with angularjs.
 - [simple-single-spa-webpack-example](https://github.com/joeldenning/simple-single-spa-webpack-example) is a small, simple example that can be used as a webpack starter.
 - [demo-single-spa-with-spax](https://github.com/crossjs/spax/tree/master/packages/demo-single-spa) is a tiny [spax](https://spax.js.org) example with react-scripts and craco.
+- [single-spa-parcel-example](https://github.com/Guillembonet/single-spa-parcel-example) is an example of one vue and one react microfrontends, containing a react and a vue parcel respectively and two node.js microservices running in 6 different Docker VM's seamlessly working together in a single web app located in a 7th VM.
 
 Have your own starter repo? [Submit a PR](https://github.com/CanopyTax/single-spa.js.org/edit/master/docs/examples.md) to add yours to this list.


### PR DESCRIPTION
Example for multiple VM's hosting the different microfrontends, microservices and parcels.

A React microfrontend containing a Vue parcel, and a Vue microfrontend containing a React parcel all hosted in different Docker VM's. The React apps connect to a microservice and the Vue apps connect to another microservice (both connected to a MongoDB).
This is an example of parcels and running microfrontends hosted in different machines (which I haven't found before).