### PR TITLE
Add FAQ about frameworks in the single-spa-config

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -13,6 +13,9 @@ The applications can all be written in the same framework, or they can be implem
 ## Is there a recommended setup?
 Yes, here is [the documentation for our recommended setup](/docs/recommended-setup/).
 
+## Should I put frameworks in the single-spa-config/root-application?
+No. We strongly encourage that your single-spa-config or root application does not use any javascript ui-frameworks (React, Angular, Angularjs, Vue, etc). In our experience a plain javascript module is best for the single-spa-config and only the registered applications actually use ui-frameworks (angular, react, vue, etc). 
+
 ## What is the impact to performance?
 When setup in the [recommended way](#is-there-a-recommended-setup), your code performance and bundle size will be nearly identical to a single application that has been code-split. The major differences will be the addition of the single-spa library (and SystemJS if you chose to use it). Other differences mainly come down to the difference between one (webpack / rollup / etc.) code bundle and in-browser ES modules.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -16,6 +16,8 @@ Yes, here is [the documentation for our recommended setup](/docs/recommended-set
 ## Should I have a parent/root app and children apps?
 No. We strongly encourage that your single-spa-config or root application does not use any javascript ui-frameworks (React, Angular, Angularjs, Vue, etc). In our experience a plain javascript module is best for the single-spa-config and only the registered applications actually use ui-frameworks (angular, react, vue, etc). 
 
+Why? You end up creating a structure that has all the disadvantages of microservices without any of the advantages: your apps are now coupled together and you have to change multiple apps at the same time in order to make updates. Good microservices are completely **independent**, and this pattern breaks that.
+
 ## What is the impact to performance?
 When setup in the [recommended way](#is-there-a-recommended-setup), your code performance and bundle size will be nearly identical to a single application that has been code-split. The major differences will be the addition of the single-spa library (and SystemJS if you chose to use it). Other differences mainly come down to the difference between one (webpack / rollup / etc.) code bundle and in-browser ES modules.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -13,7 +13,7 @@ The applications can all be written in the same framework, or they can be implem
 ## Is there a recommended setup?
 Yes, here is [the documentation for our recommended setup](/docs/recommended-setup/).
 
-## Should I put frameworks in the single-spa-config/root-application?
+## Should I have a parent/root app and children apps?
 No. We strongly encourage that your single-spa-config or root application does not use any javascript ui-frameworks (React, Angular, Angularjs, Vue, etc). In our experience a plain javascript module is best for the single-spa-config and only the registered applications actually use ui-frameworks (angular, react, vue, etc). 
 
 ## What is the impact to performance?


### PR DESCRIPTION
I think this is a common point of confusion and I've noticed an increase in questions about frameworks in the root config.