### PR TITLE
Adding languages page and nav link for it.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,3 +38,10 @@ workflows:
   build:
     jobs:
       - build-website
+
+            git config --global user.email "joeldenning@users.noreply.github.com"
+            git config --global user.name "CircleCI on behalf of Joel Denning"
+            echo "machine github.com login joeldenning password $GITHUB_TOKEN" > ~/.netrc
+            cd website
+            yarn install --frozen-lockfile
+            GIT_USER=joeldenning yarn deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,10 +38,3 @@ workflows:
   build:
     jobs:
       - build-website
-
-            git config --global user.email "joeldenning@users.noreply.github.com"
-            git config --global user.name "CircleCI on behalf of Joel Denning"
-            echo "machine github.com login joeldenning password $GITHUB_TOKEN" > ~/.netrc
-            cd website
-            yarn install --frozen-lockfile
-            GIT_USER=joeldenning yarn deploy

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -106,6 +106,7 @@ module.exports = {
         { to: 'blog/', label: 'Blog' },
         { href: 'https://opencollective.com/single-spa', label: 'Donate' },
         { href: 'https://github.com/single-spa/single-spa', label: 'GitHub' },
+        { to: 'languages', label: '简Жहि Languages'},
       ],
     },
     googleAnalytics: {

--- a/website/src/data/languages.js
+++ b/website/src/data/languages.js
@@ -1,0 +1,16 @@
+// Please keep list list in alphabetical order
+
+export default [
+  {
+    languageName: "English",
+    languageNameEnglish: "English",
+    documentationUrl: "https://single-spa.js.org",
+    githubUrl: "https://github.com/single-spa/single-spa.js.org"
+  },
+  {
+    languageName: "简体中文",
+    languageNameEnglish: "Simplified Chinese",
+    documentationUrl: "https://zh-hans.single-spa.js.org",
+    githubUrl: "https://github.com/single-spa/zh-hans.single-spa.js.org"
+  }
+]

--- a/website/src/pages/languages/index.js
+++ b/website/src/pages/languages/index.js
@@ -28,7 +28,7 @@ export default function Languages() {
           ))}
         </div>
         <div style={{display: 'flex', justifyContent: 'center'}}>
-          Don't see your language above?<a href="https://github.com/single-spa/single-spa/issues/new" style={{marginLeft: '.3rem'}}>Let us know</a>.
+          Don't see your language above?<a href="https://github.com/single-spa/single-spa.js.org/issues/new" style={{marginLeft: '.3rem'}}>Let us know</a>.
         </div>
       </div>
     </Layout>

--- a/website/src/pages/languages/index.js
+++ b/website/src/pages/languages/index.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import Layout from '@theme/Layout';
+import languages from '@site/src/data/languages';
+
+export default function Languages() {
+  return (
+    <Layout title="Languages">
+      <div className="container container--fluid padding-horiz--xl margin-top--lg">
+        <div style={{display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center'}}>
+          <h1>Languages</h1>
+          <p>
+            The single-spa documentation is available in the following languages:
+          </p>
+        </div>
+        <div className="row text--center">
+          {languages.map(language => (
+            <div
+              key={language.languageName}
+              className="col col--6 margin-vert--md padding-horiz--xl">
+              <h3>{language.languageNameEnglish}</h3>
+              <div>
+                <a href={language.documentationUrl} style={{fontSize: '1.5rem'}}>{language.languageName}</a>
+              </div>
+              <div>
+                <a href={language.githubUrl} style={{fontSize: '.75rem'}}>Contribute</a>
+              </div>
+            </div>
+          ))}
+        </div>
+        <div style={{display: 'flex', justifyContent: 'center'}}>
+          Don't see your language above?<a href="https://github.com/single-spa/single-spa/issues/new" style={{marginLeft: '.3rem'}}>Let us know</a>.
+        </div>
+      </div>
+    </Layout>
+  );
+}


### PR DESCRIPTION
We need to wait for https://github.com/js-org/js.org/pull/3747 to be merged first. But then this pull request adds ability to switch languages within the documentation.

Navbar:
<img width="745" alt="image" src="https://user-images.githubusercontent.com/5524384/75129188-14556000-5685-11ea-9cf9-dd519bb15bab.png">

Languages page:
<img width="1091" alt="image" src="https://user-images.githubusercontent.com/5524384/75129199-1ae3d780-5685-11ea-9eff-09084103ecf7.png">
