### PR TITLE
Adding Portuguese (Europe) translation. Resolves #183.

### DIFF
--- a/website/src/data/languages.js
+++ b/website/src/data/languages.js
@@ -8,6 +8,12 @@ export default [
     githubUrl: "https://github.com/single-spa/single-spa.js.org"
   },
   {
+    languageName: "Português europeu",
+    languageNameEnglish: "Portuguese (Portugal)",
+    documentationUrl: "https://pt-pt.single-spa.js.org",
+    githubUrl: "https://github.com/single-spa/pt-pt.single-spa.js.org"
+  },
+  {
     languageName: "简体中文",
     languageNameEnglish: "Simplified Chinese",
     documentationUrl: "https://zh-hans.single-spa.js.org",


### PR DESCRIPTION
See #183. Note that this depends on https://github.com/js-org/js.org/pull/3756 and should not be merged until that PR is merged.

cc @mstrlaw @guguji5 