### PR TITLE
Adding prominent slack chat link.

### DIFF
--- a/website/src/components/HomeSplash/index.js
+++ b/website/src/components/HomeSplash/index.js
@@ -24,6 +24,10 @@ export const HomeSplash = () => {
           <Link className="button" to="https://vue.microfrontends.app/rate-doggos">
             See a live example
           </Link>
+
+          <Link className="button" to="https://join.slack.com/t/single-spa/shared_invite/enQtODAwNTIyMzc4OTE1LWUxMTUwY2M1MTY0ZGMzOTUzMGNkMzI1NzRiYzYwOWM1MTEzZDM1NDAyNWM3ZmViOTAzZThkMDcwMWZmNTFmMWQ">
+            Join Slack Chat
+          </Link>
         </div>
       </div>
     </header>

--- a/website/src/components/HomeSplash/styles.module.css
+++ b/website/src/components/HomeSplash/styles.module.css
@@ -10,7 +10,7 @@ html[data-theme='dark'] .heroBanner {
   background-color: var(--ifm-color-primary-darkest);
 }
 
-.heroButtons a:first-child {
+.heroButtons a:not(:last-child) {
   margin-right: 4px;
 }
 


### PR DESCRIPTION
I think the slack workspace is important enough to a lot of people's success that it should be advertised more prominently on the home page. Do you agree?

![image](https://user-images.githubusercontent.com/5524384/77460971-7a89eb80-6dc7-11ea-8680-1df436f0dfcb.png)
