### PR TITLE
Add object config docs

### DIFF
--- a/website/src/components/Errors/Codes/38.js
+++ b/website/src/components/Errors/Codes/38.js
@@ -1,7 +1,6 @@
-import React from 'react'
+import React from 'react';
 
-export default function ErrorCode37(props) {
-
+export default function ErrorCode38(props) {
   return (
     <>
       <h1>#38: Invalid registerApplication configuration object</h1>
@@ -15,5 +14,5 @@ export default function ErrorCode37(props) {
         See <a href="/docs/configuration">registerApplication API documentation</a> for more information.
       </p>
     </>
-  )
+  );
 }

--- a/website/src/components/Errors/Codes/38.js
+++ b/website/src/components/Errors/Codes/38.js
@@ -1,0 +1,19 @@
+import React from 'react'
+
+export default function ErrorCode37(props) {
+
+  return (
+    <>
+      <h1>#38: Invalid registerApplication configuration object</h1>
+      <p>
+        The configuration object in registerApplication accepts only the following keys: "{props.getErrorCodeArg(0)}"
+      </p>
+      <p>
+        You provided the following invalid keys: "{props.getErrorCodeArg(1)}"
+      </p>
+      <p>
+        See <a href="/docs/configuration">registerApplication API documentation</a> for more information.
+      </p>
+    </>
+  )
+}

--- a/website/src/components/Errors/Codes/39.js
+++ b/website/src/components/Errors/Codes/39.js
@@ -1,0 +1,16 @@
+import React from 'react'
+
+export default function ErrorCode37() {
+
+  return (
+    <>
+      <h1>#39: Invalid registerApplication configuration object</h1>
+      <p>
+        Configuration object can't be an array or null! Please provide a plain object with correct configuration.
+      </p>
+      <p>
+        See <a href="/docs/configuration">registerApplication API documentation</a> for more information.
+      </p>
+    </>
+  )
+}

--- a/website/src/components/Errors/Codes/39.js
+++ b/website/src/components/Errors/Codes/39.js
@@ -1,7 +1,6 @@
-import React from 'react'
+import React from 'react';
 
-export default function ErrorCode37() {
-
+export default function ErrorCode39() {
   return (
     <>
       <h1>#39: Invalid registerApplication configuration object</h1>
@@ -12,5 +11,5 @@ export default function ErrorCode37() {
         See <a href="/docs/configuration">registerApplication API documentation</a> for more information.
       </p>
     </>
-  )
+  );
 }

--- a/website/versioned_docs/version-5.x/api.md
+++ b/website/versioned_docs/version-5.x/api.md
@@ -4,7 +4,7 @@ title: Applications API
 sidebar_label: Applications API
 ---
 
-single-spa exports named functions and variables rather than a single default export.
+Single-spa exports named functions and variables rather than a single default export.
 This means importing must happen in one of two ways:
 
 ```js
@@ -14,16 +14,18 @@ import * as singleSpa from 'single-spa';
 ```
 
 ## registerApplication
-
-```js
-singleSpa.registerApplication('appName', () => System.import('appName'), location => location.pathname.startsWith('appName'))
-```
-
-`registerApplication` is the most important api your root config will use. Use this function to register any application within single-spa.
-
+`registerApplication` is the most important API your root config will use. Use this function to register any application within single-spa.
 Note that if an application is registered from within another application, that no hierarchy will be maintained between the applications.
 
-> It is described in detail inside of the [Configuration docs](configuration#registering-applications)
+There are two ways of registering your application:
+### Simple arguments
+```js
+singleSpa.registerApplication(
+	'appName',
+	() => System.import('appName'),
+	location => location.pathname.startsWith('appName')
+)
+```
 
 <h3>arguments</h3>
 
@@ -41,6 +43,40 @@ Note that if an application is registered from within another application, that 
 <h3>returns</h3>
 
 `undefined`
+
+### Configuration object
+```js
+singleSpa.registerApplication({
+	name: 'appName',
+	app: () => System.import('appName'),
+	activeWhen: '/appName'
+	customProps: {}
+})
+```
+
+<h3>arguments</h3>
+
+<dl className="args-list">
+	<dt>name?: string</dt>
+	<dd>App name that single-spa will register and reference this application with, and will be labelled with in dev tools.</dd>
+	<dt>app?: Application | () => Application | Promise&lt;Application&gt; </dt>
+	<dd>Application object or a function that returns the resolved application (Promise or not)</dd>
+	<dt>activeWhen: string | (location) => boolean | (string | (location) => boolean)[]</dt>
+	<dd>Can be a path prefix which will match every URL starting with this path,
+	an activity function (as described in the simple arguments) or an array
+	containing both of them. If any of the criteria is true, it will keep the
+	application active. Examples of path prefixes: '/appName', '/users/:userId'
+	</dd>
+	<dt>customProps?: Object = &#123;&#125;</dt>
+	<dd>Will be passed to the application during each lifecycle method.</dd>
+</dl>
+
+<h3>returns</h3>
+
+`undefined`
+
+
+> It is described in detail inside of the [Configuration docs](configuration#registering-applications)
 
 ## start
 ```js

--- a/website/versioned_docs/version-5.x/api.md
+++ b/website/versioned_docs/version-5.x/api.md
@@ -75,7 +75,6 @@ singleSpa.registerApplication({
 
 `undefined`
 
-
 > It is described in detail inside of the [Configuration docs](configuration#registering-applications)
 
 ## start
@@ -291,7 +290,7 @@ Single-spa performs the following steps when unloadApplication is called.
 2. Set the app status to NOT_LOADED
 3. Trigger a reroute, during which single-spa will potentially mount the application that was just unloaded.
 
-Because a registered application might be mounted when `unloadApplication` is called, you can specify whether you want to immediately unload or if you want to wait until the application is no longer mounted. This is done with the `waitForUnmount` option. 
+Because a registered application might be mounted when `unloadApplication` is called, you can specify whether you want to immediately unload or if you want to wait until the application is no longer mounted. This is done with the `waitForUnmount` option.
 
 <h3>arguments</h3>
 
@@ -367,7 +366,7 @@ function handleErr(err) {
 }
 ```
 
-Removes the given error handler function. 
+Removes the given error handler function.
 
 <h3>arguments</h3>
 
@@ -627,7 +626,7 @@ window.addEventListener('single-spa:no-app-change', () => {
 
 When no applications were loaded, bootstrapped, mounted, unmounted, or unloaded, single-spa fires a `single-spa:no-app-change` event. This is the inverse of the `single-spa:app-change` event. Only one will be fired for each routing event.
 
-## before-first-mount	
+## before-first-mount
 
 ```js
 window.addEventListener('single-spa:before-first-mount', () => {

--- a/website/versioned_docs/version-5.x/api.md
+++ b/website/versioned_docs/version-5.x/api.md
@@ -57,15 +57,39 @@ singleSpa.registerApplication({
 <h3>arguments</h3>
 
 <dl className="args-list">
-	<dt>name?: string</dt>
+	<dt>name: string</dt>
 	<dd>App name that single-spa will register and reference this application with, and will be labelled with in dev tools.</dd>
-	<dt>app?: Application | () => Application | Promise&lt;Application&gt; </dt>
+	<dt>app: Application | () => Application | Promise&lt;Application&gt; </dt>
 	<dd>Application object or a function that returns the resolved application (Promise or not)</dd>
 	<dt>activeWhen: string | (location) => boolean | (string | (location) => boolean)[]</dt>
 	<dd>Can be a path prefix which will match every URL starting with this path,
 	an activity function (as described in the simple arguments) or an array
 	containing both of them. If any of the criteria is true, it will keep the
-	application active. Examples of path prefixes: '/appName', '/users/:userId'
+	application active. The path prefix also accepts dynamic values (they must
+	start with ':'), as some paths would receive url params and should still
+	trigger your application.
+	Examples:
+		<dl>
+			<dt>'/app1'</dt>
+			<dd>✅ https://app.com/app1</dd>
+			<dd>✅ https://app.com/app1/anything/everything</dd>
+      <dd>🚫 https://app.com/app2</dd>
+			<dt>'/users/:userId/profile'</dt>
+			<dd>✅ https://app.com/users/123/profile</dd>
+			<dd>✅ https://app.com/users/123/profile/sub-profile/</dd>
+			<dd>🚫 https://app.com/users//profile/sub-profile/</dd>
+			<dd>🚫 https://app.com/users/profile/sub-profile/</dd>
+			<dt>'/pathname/#/hash'</dt>
+			<dd>✅ https://app.com/pathname/#/hash</dd>
+			<dd>✅ https://app.com/pathname/#/hash/route/nested</dd>
+			<dd>🚫 https://app.com/pathname#/hash/route/nested</dd>
+			<dd>🚫 https://app.com/pathname#/another-hash</dd>
+      <dt>['/pathname/#/hash', '/app1']</dt>
+			<dd>✅ https://app.com/pathname/#/hash/route/nested</dd>
+			<dd>✅ https://app.com/app1/anything/everything</dd>
+			<dd>🚫 https://app.com/pathname/app1</dd>
+			<dd>🚫 https://app.com/app2</dd>
+		</dl>
 	</dd>
 	<dt>customProps?: Object = &#123;&#125;</dt>
 	<dd>Will be passed to the application during each lifecycle method.</dd>

--- a/website/versioned_docs/version-5.x/building-applications.md
+++ b/website/versioned_docs/version-5.x/building-applications.md
@@ -37,7 +37,7 @@ function bootstrap(props) {
   const {
     name,        // The name of the application
     singleSpa,   // The singleSpa instance
-    mountParcel, // Function for manually mounting 
+    mountParcel, // Function for manually mounting
     customProps  // Additional custom information
   } = props;     // Props are given to every lifecycle
   return Promise.resolve();
@@ -61,12 +61,12 @@ In addition to the built-in props that are provided by single-spa, you may optio
 <p className="filename">root.application.js</p>
 
 ```js
-singleSpa.registerApplication(
-  'app1', 
-  () => {}, 
-  () => {}, 
-  { authToken: "d83jD63UdZ6RS6f70D0" }
-);
+singleSpa.registerApplication({
+  name: 'app1',
+  activeWhen,
+  app,
+  customProps: { authToken: "d83jD63UdZ6RS6f70D0" }
+});
 ```
 
 <p className="filename">app1.js</p>

--- a/website/versioned_docs/version-5.x/ecosystem-angularjs.md
+++ b/website/versioned_docs/version-5.x/ecosystem-angularjs.md
@@ -76,7 +76,11 @@ window.myAngularApp = singleSpaAngularJS({
 
 Your [loading function](/docs/configuration.html#loading-function-or-application) should just be the global variable itself. For example:
 ```js
-singleSpa.registerApplication('my-angular-app', myAngularApp, () => true);
+singleSpa.registerApplication({
+  name: 'my-angular-app',
+  app: myAngularApp,
+  activeWhen: () => true
+});
 ```
 
 ## Options

--- a/website/versioned_docs/version-5.x/ecosystem-ember.md
+++ b/website/versioned_docs/version-5.x/ecosystem-ember.md
@@ -33,11 +33,11 @@ Note that the loading and activity functions are part of the [single-spa root ap
 import {registerApplication} from 'single-spa';
 import {loadEmberApp} from 'single-spa-ember';
 
-const appName = 'ember-app';
-const loadingFunction = () => loadEmberApp(appName, '/dist/ember-app/assets/ember-app.js', '/dist/ember-app/assets/vendor.js');
-const activityFunction = location => location.hash.startsWith('ember');
+const name = 'ember-app';
+const app = () => loadEmberApp(name, '/dist/ember-app/assets/ember-app.js', '/dist/ember-app/assets/vendor.js');
+const activeWhen = location => location.hash.startsWith('ember');
 
-registerApplication(appName, loadingFunction, activityFunction);
+registerApplication({ name, app, activeWhen });
 ```
 
 ### singleSpaEmber
@@ -86,7 +86,7 @@ module.exports = function(defaults) {
 		},
     // Add options here
   });
-  
+
   // Tell ember how to use the single-spa-ember library
   app.import('bower_components/single-spa-ember/amd/single-spa-ember.js', {
 		using: [

--- a/website/versioned_docs/version-5.x/ecosystem-html-web-components.md
+++ b/website/versioned_docs/version-5.x/ecosystem-html-web-components.md
@@ -46,7 +46,11 @@ const webComponentApp = window.singleSpaHtml.default({
   template: props => `<x-my-web-component attr="${props.attr}"></x-my-web-component>`,
 })
 
-singleSpa.registerApplication('name', webComponentApp, () => true)
+singleSpa.registerApplication({
+  name: 'name',
+  app: webComponentApp,
+  activeWhen: () => true
+})
 ```
 
 ## API / Options

--- a/website/versioned_docs/version-5.x/ecosystem-react.md
+++ b/website/versioned_docs/version-5.x/ecosystem-react.md
@@ -1,5 +1,5 @@
 ---
-id: ecosystem-react 
+id: ecosystem-react
 title: single-spa-react
 sidebar_label: React
 ---
@@ -52,8 +52,8 @@ All options are passed to single-spa-react via the `opts` parameter when calling
 - `domElementGetter`: (optional) A function that takes in no arguments and returns a DOMElement. This dom element is where the
   React application will be bootstrapped, mounted, and unmounted. Note that this opt can be omitted. When omitted, the `domElementGetter` or `domElement`
   [custom single-spa props](https://single-spa.js.org/docs/building-applications/#custom-props) are used.
-  To use those, do `singleSpa.registerApplication(name, app, activityFn, {domElementGetter: function() {...}})` or
-  `singleSpa.registerApplication(name, app, activityFn, {domElement: document.getElementById(...)})`. If no dom element can be found through any
+  To use those, do `singleSpa.registerApplication({ name, app, activeWhen, customProps: {domElementGetter: function() {...}} })` or
+  `singleSpa.registerApplication({ name, app, activeWhen, {domElement: document.getElementById(...)} })`. If no dom element can be found through any
   of those methods, then a container div will be created and appended to document.body, by default.
 - `parcelCanUpdate`: (optional) A boolean that controls whether an update lifecycle will be created for the returned parcel. Note that option does not impact single-spa applications, but only parcels.
   It is true by default.

--- a/website/versioned_docs/version-5.x/getting-started-overview.md
+++ b/website/versioned_docs/version-5.x/getting-started-overview.md
@@ -92,20 +92,21 @@ To create a single-spa application, you will need to do three things:
 ```js
 import * as singleSpa from 'single-spa';
 
-const appName = 'app1';
+const name = 'app1';
 
-/* The loading function is a function that returns a promise that resolves with the javascript application module.
+/* The app can be a resolved application or a function that returns a promise that resolves with the javascript application module.
  * The purpose of it is to facilitate lazy loading -- single-spa will not download the code for a application until it needs to.
  * In this example, import() is supported in webpack and returns a Promise, but single-spa works with any loading function that returns a Promise.
  */
-const loadingFunction = () => import('./app1/app1.js');
+const app = () => import('./app1/app1.js');
 
 /* single-spa does some top-level routing to determine which application is active for any url. You can implement this routing any way you'd like.
  * One useful convention might be to prefix the url with the name of the app that is active, to keep your top-level routing simple.
  */
-const activityFunction = location => location.pathname.startsWith('/app1');
+const activeWhen = '/app1';
 
-singleSpa.registerApplication(appName, loadingFunction, activityFunction);
+singleSpa.registerApplication({ name, app, activeWhen });
+
 singleSpa.start();
 ```
 

--- a/website/versioned_docs/version-5.x/single-spa-config.md
+++ b/website/versioned_docs/version-5.x/single-spa-config.md
@@ -107,19 +107,34 @@ The definition of your app, which can be an object with single-spa lifecycle
 methods, or a loading function, the same as the second argument on the arguments API
 
 #### config.activeWhen
-Can be an activity function, like the arguments API, a path prefix or and array
+Can be an activity function, like the arguments API, a path prefix or an array
 with both. Since the most common use case is to look at the `window.location` and match the URL with a
 prefix, we decided to do this for you!
 
 #### Path prefix
 The path prefix will match the start of your URL, allowing everything after the
 prefix. Examples:
-- '/myApp' will match https://my.app.com/myApp and https://my.app.com/myApp/anything/everything
-- '/users/:userId' will match https://my.app.com/users/1 and https://my.app.com/users/1/anyhthing/everything
-- '/#/allow/for/:hash/route' will match https://my.app.com/#/allow/for/whatever-in-dynamic-subroute/route
-- 'bothPathname/#/and/:hash/route' will match https://my.app.com/bothPathName/#/and/123/route
-- '/path/:dynamic/another' will NOT match https://my.app.com/path//another
-- '/path/:dynamic/another' will NOT match https://my.app.com/path/another
+  <dl>
+    <dt>'/app1'</dt>
+    <dd>✅ https://app.com/app1</dd>
+    <dd>✅ https://app.com/app1/anything/everything</dd>
+    <dd>🚫 https://app.com/app2</dd>
+    <dt>'/users/:userId/profile'</dt>
+    <dd>✅ https://app.com/users/123/profile</dd>
+    <dd>✅ https://app.com/users/123/profile/sub-profile/</dd>
+    <dd>🚫 https://app.com/users//profile/sub-profile/</dd>
+    <dd>🚫 https://app.com/users/profile/sub-profile/</dd>
+    <dt>'/pathname/#/hash'</dt>
+    <dd>✅ https://app.com/pathname/#/hash</dd>
+    <dd>✅ https://app.com/pathname/#/hash/route/nested</dd>
+    <dd>🚫 https://app.com/pathname#/hash/route/nested</dd>
+    <dd>🚫 https://app.com/pathname#/another-hash</dd>
+    <dt>['/pathname/#/hash', '/app1']</dt>
+    <dd>✅ https://app.com/pathname/#/hash/route/nested</dd>
+    <dd>✅ https://app.com/app1/anything/everything</dd>
+    <dd>🚫 https://app.com/pathname/app1</dd>
+    <dd>🚫 https://app.com/app2</dd>
+  </dl>
 
 ## Calling singleSpa.start()
 The [`start()` api](api.md#start) **must** be called by your single spa config in order for

--- a/website/versioned_docs/version-5.x/single-spa-config.md
+++ b/website/versioned_docs/version-5.x/single-spa-config.md
@@ -115,12 +115,11 @@ prefix, we decided to do this for you!
 The path prefix will match the start of your URL, allowing everything after the
 prefix. Examples:
 - '/myApp' will match https://my.app.com/myApp and https://my.app.com/myApp/anything/everything
-- '/users/:userId' will match https://my.app.com/users/1 and https://my.app.com/users/1/anyhthing/everything 
+- '/users/:userId' will match https://my.app.com/users/1 and https://my.app.com/users/1/anyhthing/everything
 - '/#/allow/for/:hash/route' will match https://my.app.com/#/allow/for/whatever-in-dynamic-subroute/route
 - 'bothPathname/#/and/:hash/route' will match https://my.app.com/bothPathName/#/and/123/route
 - '/path/:dynamic/another' will NOT match https://my.app.com/path//another
 - '/path/:dynamic/another' will NOT match https://my.app.com/path/another
-
 
 ## Calling singleSpa.start()
 The [`start()` api](api.md#start) **must** be called by your single spa config in order for


### PR DESCRIPTION
- Add documentation for configuration object on `registerApplication`
- Add error 38, regarding the accept keys in the configuration object (pending PR to send valid keys and invalid keys to improve error UX)
- Add error 39, saying it only accepts a configuration object which is not an array and not null