### PR TITLE
fix broken help link in getting started

### DIFF
--- a/website/versioned_docs/version-4.x/getting-started-overview.md
+++ b/website/versioned_docs/version-4.x/getting-started-overview.md
@@ -63,7 +63,7 @@ The documentation is divided into several sections:
 * [Ecosystem](ecosystem.md)
 * [Contributing Guide](contributing-overview.md)
 * [Blog](https://single-spa.js.org/blog/)
-* [Where to Get Support](https://single-spa.js.org/en/help.html)
+* [Where to Get Support](https://single-spa.js.org/help/)
 
 You can help improve the single-spa website by sending pull requests to the [`single-spa.js.org` repository](https://github.com/single-spa/single-spa.js.org).
 

--- a/website/versioned_docs/version-5.x/getting-started-overview.md
+++ b/website/versioned_docs/version-5.x/getting-started-overview.md
@@ -64,7 +64,7 @@ The documentation is divided into several sections:
 * [Ecosystem](ecosystem.md)
 * [Contributing Guide](contributing-overview.md)
 * [Blog](https://single-spa.js.org/blog/)
-* [Where to Get Support](https://single-spa.js.org/en/help.html)
+* [Where to Get Support](https://single-spa.js.org/help/)
 
 You can help improve the single-spa website by sending pull requests to the [`single-spa.js.org` repository](https://github.com/single-spa/single-spa.js.org).
 


### PR DESCRIPTION
In getting started overview, the link `https://single-spa.js.org/en/help.html` navigates to 404 page. I've changed the link to correct help page.