### PR TITLE
change footer logo and canopy url

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -31,7 +31,7 @@ module.exports = {
     footer: {
       logo: {
         alt: 'single-spa',
-        src: 'img/canopy-logo-icon.svg',
+        src: 'img/logo-white-bgblue.svg',
       },
       copyright: `Copyright © ${new Date().getFullYear()} single-spa.`,
       style: 'dark',

--- a/website/src/data/users.js
+++ b/website/src/data/users.js
@@ -2,7 +2,7 @@ const users = [
   {
     caption: 'CanopyTax',
     image: 'img/canopy-logo-icon.svg',
-    infoLink: 'https://www.canopytax.com',
+    infoLink: 'https://www.getcanopy.com/',
     pinned: true,
   },
   {

--- a/website/src/theme/Footer/index.js
+++ b/website/src/theme/Footer/index.js
@@ -91,13 +91,10 @@ function Footer() {
         {(logo || copyright) && (
           <div className="text--center">
             {logo && logo.src && (
-              <a
+              <img
                 className="footer__logo margin-bottom--sm"
-                href="https://www.canopytax.com/"
-                target="_blank"
-                rel="noopener noreferrer">
-                <img alt={logo.alt} src={useBaseUrl(logo.src)} />
-              </a>
+                alt={logo.alt} src={useBaseUrl(logo.src)}
+              />
             )}
             {copyright}
           </div>

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -81,17 +81,11 @@ blockquote p:nth-child(2n) {
 }
 
 .footer__logo {
-  background: var(--ifm-color-white);
   border-radius: 3px;
   display: block;
   margin: 0 auto 1rem;
-  opacity: 0.7;
   transition: opacity 0.15s ease-in-out;
   width: 38px;
-}
-
-.footer__logo:hover {
-  opacity: 1;
 }
 
 .footer__logo img {


### PR DESCRIPTION
![Screen Shot 2020-04-21 at 3 04 40 PM](https://user-images.githubusercontent.com/1293874/79919381-84fdcc00-83eb-11ea-8b9c-d4b96436a956.png)


- changed footer to use single-spa's logo (not a canopy project anymore)
- removed the canopy anchor around the logo
- updated canopy's url