### PR TITLE
Fixing contributors page

### DIFF
--- a/website/src/pages/contributors/index.js
+++ b/website/src/pages/contributors/index.js
@@ -9,7 +9,7 @@ const TITLE = 'Core Team Members';
 
 const getContributors = token => `
   ${JSON.stringify(projects)}.forEach(({user, repo}) => {
-    fetch(\`https://api.github.com/repos/\${user}/\${repo}/contributors?access_token=${token}\`)
+    fetch(\`https://api.github.com/repos/\${user}/\${repo}/contributors\`)
       .then(res => res.json())
       .then(data => {
         const contributors = data.map(({html_url, login, id, avatar_url}) => (\`  


### PR DESCRIPTION
This access token is not needed to call the Github API, and it's now an invalid token. I think it was originally from @alocke12992, but is not needed. Removing it fixes the contributors page

Before:
![image](https://user-images.githubusercontent.com/5524384/80427318-b8859e00-88a4-11ea-9599-ed3d18038e56.png)

After:

![image](https://user-images.githubusercontent.com/5524384/80427347-c0ddd900-88a4-11ea-8bed-7a7a57165227.png)
