### PR TITLE
Fixing link to registering application docs. Resolves #255.

### DIFF
--- a/website/versioned_docs/version-5.x/building-applications.md
+++ b/website/versioned_docs/version-5.x/building-applications.md
@@ -8,7 +8,7 @@ A single-spa registered application is everything that a normal SPA is, except t
 
 ## Creating a registered application
 
-To create a registered application, first [register the application with single-spa](configuration#registering-applications). Once registered, the registered application must correctly implement **all** of the following lifecycle functions inside of its main entry point.
+To create a registered application, first [register the application with single-spa](./configuration/#registering-applications). Once registered, the registered application must correctly implement **all** of the following lifecycle functions inside of its main entry point.
 
 ## Registered application lifecycle
 


### PR DESCRIPTION
See #255.

Old link (broken):
https://single-spa.js.org/docs/building-applications/configuration/#registering-applications

New link (works):
https://single-spa.js.org/docs/configuration/#registering-applications