### PR TITLE
Match svelte's equity banner style

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -20,7 +20,7 @@ module.exports = {
   },
   scripts: [
     'https://unpkg.com/vanilla-back-to-top@7.2.1/dist/vanilla-back-to-top.min.js',
-    'https://cdn.jsdelivr.net/npm/racial-equity-banner@1.0.1/racial-equity-banner-bottom.js',
+    'https://cdn.jsdelivr.net/npm/racial-equity-banner@1.0.3/racial-equity-banner-bottom.js',
     '/js/index.js',
   ],
   themeConfig: {


### PR DESCRIPTION
Changed the style of the banner to match what is found on svelte's homepage: https://github.com/blittle/racial-equity-banner#example
