### PR TITLE
Fixes a few typos, grammar issues, and inconsistencies in the docs

### DIFF
--- a/website/versioned_docs/version-4.x/ecosystem-leaked-globals.md
+++ b/website/versioned_docs/version-4.x/ecosystem-leaked-globals.md
@@ -39,8 +39,7 @@ single-spa-leaked-globals won't work for you.
 ```sh
 npm install --save single-spa-leaked-globals
 
-# Or
-
+# or
 yarn add single-spa-leaked-globals
 ```
 

--- a/website/versioned_docs/version-4.x/ecosystem-react.md
+++ b/website/versioned_docs/version-4.x/ecosystem-react.md
@@ -12,7 +12,7 @@ single-spa-react is a helper library that helps implement [single-spa registered
 ```sh
 npm install --save single-spa-react
 
-# Or
+# or
 yarn add single-spa-react
 ```
 

--- a/website/versioned_docs/version-4.x/examples.md
+++ b/website/versioned_docs/version-4.x/examples.md
@@ -11,7 +11,7 @@ There are a variety of single-spa example repositories, each for different use c
 - [single-spa-es5-angularjs](https://github.com/joeldenning/single-spa-es5-angularjs) is a very tiny es5 example with angularjs.
 - [simple-single-spa-webpack-example](https://github.com/joeldenning/simple-single-spa-webpack-example) is a small, simple example that can be used as a webpack starter.
 - [demo-single-spa-with-spax](https://github.com/crossjs/spax/tree/master/packages/demo-single-spa) is a tiny [spax](https://spax.js.org) example with react-scripts and craco.
-- [single-spa-parcel-example](https://github.com/Guillembonet/single-spa-parcel-example) is an example of one vue and one react microfrontends, containing a react and a vue parcel respectively and two node.js microservices running in 6 different Docker VM's seamlessly working together in a single web app located in a 7th VM.
+- [single-spa-parcel-example](https://github.com/Guillembonet/single-spa-parcel-example) is an example of one Vue and one React microfrontend, containing a React and a Vue parcel respectively and two Node.js microservices running in 6 different Docker VMs seamlessly working together in a single web app located in a 7th VM.
 - [single-spa-login-example-with-npm-packages](https://github.com/jualoppaz/single-spa-login-example-with-npm-packages) is a single-spa application example which imports registered applications from NPM packages and manages authentication features as login.
 
 Have your own starter repo? [Submit a PR](https://github.com/single-spa/single-spa.js.org/edit/master/docs/examples.md) to add yours to this list.

--- a/website/versioned_docs/version-4.x/getting-started-overview.md
+++ b/website/versioned_docs/version-4.x/getting-started-overview.md
@@ -4,17 +4,17 @@ title: Getting Started with single-spa
 sidebar_label: Overview of single-spa
 ---
 
-## JavaScript microfrontends
+## JavaScript Microfrontends
 
 single-spa is a framework for bringing together multiple javascript microfrontends in a frontend application. Architecting your frontend using single-spa enables many benefits, such as:
 
 - [Use multiple frameworks](ecosystem.md#help-for-frameworks) on the same page [without page refreshing](building-applications.md)
   ([React](ecosystem-react.md), [AngularJS](ecosystem-angularjs.md), [Angular](ecosystem-angular.md), [Ember](ecosystem-ember.md), or whatever you're using)
-- Deploy your microfrontends independently.
+- Deploy your microfrontends independently
 - Write code using a new framework, without rewriting your existing app
-- Lazy load code for improved initial load time.
+- Lazy load code for improved initial load time
 
-## Demo and examples
+## Demo and Examples
 
 Visit the [live demo](https://single-spa.surge.sh) for an example that highlights single-spa usage. The source code is available in the [single-spa-examples](https://github.com/single-spa/single-spa-examples) repository.
 
@@ -23,11 +23,11 @@ Also, you can check out a [simple webpack starter project](https://github.com/jo
 ## Architectural Overview
 
 single-spa takes inspiration from modern framework component lifecycles by applying lifecycles to entire applications.
-It was born out of Canopy's desire to use React + react-router instead of being forever stuck with our AngularJS + ui-router application, and now single-spa supports almost any framework. Since JavaScript is notorious for the short-life of its many frameworks, we decided to make it easy to use whichever frameworks you want.
+It was born out of Canopy's desire to use React + react-router instead of being forever stuck with our AngularJS + ui-router application, and now single-spa supports almost any framework. Since JavaScript is notorious for the short life of its many frameworks, we decided to make it easy to use whichever frameworks you want.
 
 single-spa apps consist of the following:
 
-1. [Applications](building-applications.md), each of which is an entire SPA itself (sort of). Each application can respond to url routing events and must know how to bootstrap, mount, and unmount themselves from the DOM. The main difference between a traditional SPA and single-spa applications is that they must be able to coexist with other applications, and they do not each have their own html page.
+1. [Applications](building-applications.md), each of which is an entire SPA itself (sort of). Each application can respond to url routing events and must know how to bootstrap, mount, and unmount itself from the DOM. The main difference between a traditional SPA and single-spa applications is that they must be able to coexist with other applications, and they do not each have their own html page.
 
     For example, your React or Angular SPAs are applications. When active, they listen to url routing events and put content on the DOM. When inactive, they do not listen to url routing events and are totally removed from the DOM.
 2. A [single-spa-config](configuration), which is the html page _and_ the JavaScript that registers applications with single-spa. Each application is registered with three things:
@@ -73,7 +73,7 @@ For a full example, check out [this simple webpack example](https://github.com/j
 
 To create a single-spa application, you will need to do three things:
 
-1. Create an html file:
+1. Create an html file.
 
 ```html
 <html>

--- a/website/versioned_docs/version-5.x/create-single-spa.md
+++ b/website/versioned_docs/version-5.x/create-single-spa.md
@@ -55,7 +55,7 @@ Here are the available CLI options:
 
 ### --dir
 
-You may specify which directory create-single-spa runs in the following ways:
+You may specify which directory create-single-spa runs in through either of the following ways:
 
 ```sh
 # Two ways of doing the same thing
@@ -116,6 +116,7 @@ A shareable, customizable webpack config that is used for utility modules and Re
 ```sh
 npm install --save-dev webpack-config-single-spa webpack-merge
 
+# or
 yarn add --dev webpack-config-single-spa webpack-merge
 ```
 
@@ -152,6 +153,7 @@ A shareable, customizable webpack config that adds react-specific configuration 
 ```sh
 npm install --save-dev webpack-config-single-spa-react webpack-merge
 
+# or
 yarn add --dev webpack-config-single-spa-react webpack-merge
 ```
 
@@ -188,6 +190,7 @@ A shareable, customizable webpack config that adds typescript-specific configura
 ```sh
 npm install --save-dev webpack-config-single-spa-ts webpack-merge
 
+# or
 yarn add --dev webpack-config-single-spa-ts webpack-merge
 ```
 
@@ -232,6 +235,7 @@ A shareable, customizable webpack config that creates a webpack config that work
 ```sh
 npm install --save-dev webpack-config-single-spa-react-ts webpack-merge
 
+# or
 yarn add --dev webpack-config-single-spa-react-ts webpack-merge
 ```
 

--- a/website/versioned_docs/version-5.x/ecosystem-dojo.md
+++ b/website/versioned_docs/version-5.x/ecosystem-dojo.md
@@ -12,7 +12,7 @@ single-spa-dojo is a helper library that helps implement [single-spa registered 
 ```sh
 npm install --save single-spa-dojo
 
-# Or
+# or
 yarn add single-spa-dojo
 ```
 

--- a/website/versioned_docs/version-5.x/ecosystem-leaked-globals.md
+++ b/website/versioned_docs/version-5.x/ecosystem-leaked-globals.md
@@ -39,8 +39,7 @@ single-spa-leaked-globals won't work for you.
 ```sh
 npm install --save single-spa-leaked-globals
 
-# Or
-
+# or
 yarn add single-spa-leaked-globals
 ```
 

--- a/website/versioned_docs/version-5.x/ecosystem-react.md
+++ b/website/versioned_docs/version-5.x/ecosystem-react.md
@@ -12,7 +12,7 @@ single-spa-react is a helper library that helps implement [single-spa registered
 ```sh
 npm install --save single-spa-react
 
-# Or
+# or
 yarn add single-spa-react
 ```
 

--- a/website/versioned_docs/version-5.x/examples.md
+++ b/website/versioned_docs/version-5.x/examples.md
@@ -18,13 +18,13 @@ sidebar_label: Resources
 - [coexisting-angular-microfrontends](https://github.com/joeldenning/coexisting-angular-microfrontends) is a full blown Angular 8 microfrontends repo that combines three separate Angular CLI projects into one page.
 - [coexisting-vue-microfrontends](https://github.com/joeldenning/coexisting-vue-microfrontends) shows three separate Vue CLI projects existing within one page.
 - [single-spa-portal-example](https://gitlab.com/TheMcMurder/single-spa-portal-example) is a great example of coexisting React microfrontends.
-- [single-spa-parcel-example](https://github.com/Guillembonet/single-spa-parcel-example) is an example of one vue and one react microfrontends, containing a react and a vue parcel respectively and two node.js microservices running in 6 different Docker VM's seamlessly working together in a single web app located in a 7th VM.
+- [single-spa-parcel-example](https://github.com/Guillembonet/single-spa-parcel-example) is an example of one Vue and one React microfrontend, containing a React and a Vue parcel respectively and two Node.js microservices running in 6 different Docker VMs seamlessly working together in a single web app located in a 7th VM.
 - [simple-single-spa-webpack-example](https://github.com/joeldenning/simple-single-spa-webpack-example) is a small, simple example that can be used as a webpack starter.
 
 ## Community examples
 
 - [single-spa-login-example-with-npm-packages](https://github.com/jualoppaz/single-spa-login-example-with-npm-packages) is a single-spa application example which imports registered applications from NPM packages and manages authentication features as login.
 - [demo-single-spa-with-spax](https://github.com/crossjs/spax/tree/master/packages/demo-single-spa) is a tiny [spax](https://spax.js.org) example with react-scripts and craco.
-- [single-spa-html with js example](https://github.com/filoxo/single-spa-html-with-js-example): an example repo of using single-spa-html that is enhanced with plain JavaScript.
+- [single-spa-html with js example](https://github.com/filoxo/single-spa-html-with-js-example) is an example repo of using single-spa-html that is enhanced with plain JavaScript.
 
 Have your own starter repo? [Submit a PR](https://github.com/single-spa/single-spa.js.org/edit/master/docs/examples.md) to add yours to this list.

--- a/website/versioned_docs/version-5.x/getting-started-overview.md
+++ b/website/versioned_docs/version-5.x/getting-started-overview.md
@@ -4,7 +4,7 @@ title: Getting Started with single-spa
 sidebar_label: Overview of single-spa
 ---
 
-## JavaScript microfrontends
+## JavaScript Microfrontends
 
 [Join the chat on Slack](https://join.slack.com/t/single-spa/shared_invite/enQtODAwNTIyMzc4OTE1LWUxMTUwY2M1MTY0ZGMzOTUzMGNkMzI1NzRiYzYwOWM1MTEzZDM1NDAyNWM3ZmViOTAzZThkMDcwMWZmNTFmMWQ)
 
@@ -12,22 +12,22 @@ single-spa is a framework for bringing together multiple javascript microfronten
 
 - [Use multiple frameworks](ecosystem.md#help-for-frameworks) on the same page [without page refreshing](building-applications.md)
   ([React](ecosystem-react.md), [AngularJS](ecosystem-angularjs.md), [Angular](ecosystem-angular.md), [Ember](ecosystem-ember.md), or whatever you're using)
-- Deploy your microfrontends independently.
+- Deploy your microfrontends independently
 - Write code using a new framework, without rewriting your existing app
-- Lazy load code for improved initial load time.
+- Lazy load code for improved initial load time
 
-## Demos and examples
+## Demos and Examples
 
 See [our examples page](/docs/examples).
 
 ## Architectural Overview
 
 single-spa takes inspiration from modern framework component lifecycles by applying lifecycles to entire applications.
-It was born out of Canopy's desire to use React + react-router instead of being forever stuck with our AngularJS + ui-router application, and now single-spa supports almost any framework. Since JavaScript is notorious for the short-life of its many frameworks, we decided to make it easy to use whichever frameworks you want.
+It was born out of Canopy's desire to use React + react-router instead of being forever stuck with our AngularJS + ui-router application, and now single-spa supports almost any framework. Since JavaScript is notorious for the short life of its many frameworks, we decided to make it easy to use whichever frameworks you want.
 
 single-spa apps consist of the following:
 
-1. [Applications](building-applications.md), each of which is an entire SPA itself (sort of). Each application can respond to url routing events and must know how to bootstrap, mount, and unmount themselves from the DOM. The main difference between a traditional SPA and single-spa applications is that they must be able to coexist with other applications, and they do not each have their own html page.
+1. [Applications](building-applications.md), each of which is an entire SPA itself (sort of). Each application can respond to url routing events and must know how to bootstrap, mount, and unmount itself from the DOM. The main difference between a traditional SPA and single-spa applications is that they must be able to coexist with other applications, and they do not each have their own html page.
 
     For example, your React or Angular SPAs are applications. When active, they listen to url routing events and put content on the DOM. When inactive, they do not listen to url routing events and are totally removed from the DOM.
 2. A [single-spa-config](configuration), which is the html page _and_ the JavaScript that registers applications with single-spa. Each application is registered with three things:
@@ -74,7 +74,7 @@ For a full example, check out [this simple webpack example](https://github.com/j
 
 To create a single-spa application, you will need to do three things:
 
-1. Create an html file:
+1. Create an html file.
 
 ```html
 <html>

--- a/website/versioned_docs/version-5.x/layout-overview.md
+++ b/website/versioned_docs/version-5.x/layout-overview.md
@@ -29,6 +29,7 @@ You only need to install the layout engine into your [root config](./configurati
 ```sh
 npm install --save single-spa-layout@beta
 
+# or
 yarn add single-spa-layout@beta
 ```
 

--- a/website/versioned_docs/version-5.x/videos.md
+++ b/website/versioned_docs/version-5.x/videos.md
@@ -1,6 +1,6 @@
 ---
 id: videos
-title: Video tutorials
+title: Video Tutorials
 sidebar_label: Videos
 ---
 
@@ -8,11 +8,11 @@ sidebar_label: Videos
 
 A variety of video tutorials exist from both the single-spa core team and other community members.
 
-## From core team
+## From the Core Team
 
 [Youtube Playlist](https://www.youtube.com/playlist?list=PLLUD8RtHvsAOhtHnyGx57EYXoaNsxGrTU) / [Bilibili](https://space.bilibili.com/495254378)
 
-## From community
+## From the Community
 
 Feel free to add your tutorial videos to this list!
 


### PR DESCRIPTION
So far I've gone through these pages in the docs and tried to correct issues as I found them:

- https://single-spa.js.org/docs/getting-started-overview
- https://single-spa.js.org/docs/examples
- https://single-spa.js.org/docs/videos
- https://single-spa.js.org/docs/create-single-spa

Nothing major here, but having some clean documentation is a nice touch for making a project look professional!