### PR TITLE
Removes the reference to react-specific apps in the docs

### DIFF
--- a/website/versioned_docs/version-5.x/create-single-spa.md
+++ b/website/versioned_docs/version-5.x/create-single-spa.md
@@ -109,7 +109,7 @@ A [Yeoman generator](https://yeoman.io/) that prompts the user and then creates 
 
 [Github project](https://github.com/single-spa/create-single-spa/tree/master/packages/webpack-config-single-spa)
 
-A shareable, customizable webpack config that is used for utility modules and React single-spa applications.
+A shareable, customizable webpack config that is used for utility modules and single-spa applications.
 
 ### Installation
 


### PR DESCRIPTION
The docs said that `webpack-config-single-spa` was a webpack config for React single-spa applications, but I don't think that's true, right? It seems like this is a base config and then it gets extended by all the other packages like `webpack-config-single-spa-react` to make them framework-specific. I also don't see any dependencies on React in the package (https://github.com/single-spa/create-single-spa/blob/master/packages/webpack-config-single-spa/package.json), so I'm fairly certain this was a simple error in the docs.

Before:
![image](https://user-images.githubusercontent.com/13806458/83923568-ca7a1c80-a73f-11ea-84b8-600a030436bc.png)

After:
![image](https://user-images.githubusercontent.com/13806458/83923587-d1a12a80-a73f-11ea-8ba8-295cfe109409.png)

