### PR TITLE
Makes the casing consistent in many places

### DIFF
--- a/website/blog/2016-12-16-a-step-by-step-guide-to-single-spa.md
+++ b/website/blog/2016-12-16-a-step-by-step-guide-to-single-spa.md
@@ -23,15 +23,15 @@ JSPM/SystemJS has worse documentation than Webpack, but is a great solution for 
 
 If you’re struggling to decide between the two, then ask yourself the following: Do I want multiple completely separate bundles? If you don’t, I recommend Webpack because it has better docs, a larger community, and fewer gotchas. Otherwise, I’d go with JSPM, since Webpack has no plans to support dynamic runtime loading [(See tweet below from Mr. Larkin, himself)](https://twitter.com/TheLarkInn/status/789968589419745280).
 
-## Step Two: create a brand new html file
+## Step Two: create a brand new HTML file
 
-The next step is to create what single-spa calls your [“root application.”](https://github.com/single-spa/single-spa/blob/master/docs/root-application.md) Really your root application is just the stuff that initializes single-spa, and it starts with an html file.
+The next step is to create what single-spa calls your [“root application.”](https://github.com/single-spa/single-spa/blob/master/docs/root-application.md) Really your root application is just the stuff that initializes single-spa, and it starts with an HTML file.
 
-Even if you’ve got an existing project that already has it’s own html file, I recommend starting fresh with a new html file. That way, there is a clear distinction between what is in your root application (shared between all apps) and what is in a child application (not shared with everything).
+Even if you’ve got an existing project that already has it’s own HTML file, I recommend starting fresh with a new HTML file. That way, there is a clear distinction between what is in your root application (shared between all apps) and what is in a child application (not shared with everything).
 
 You’ll want to keep your root application as small as possible, since it’s sort of the master controller of everything and could become a bottleneck. You don’t want to be constantly changing both the root application and the child applications.
 
-So for now, just have a `<script>` to a single javascript file (root-application.js), which will be explained in Step Three.
+So for now, just have a `<script>` to a single JavaScript file (root-application.js), which will be explained in Step Three.
 
 Since Webpack is probably the more common use case, my code examples from here on will assume that you’re using Webpack 2. The equivalent Webpack 1 or JSPM code has all the same concepts and only some minor code differences.
 

--- a/website/blog/2018-06-19-single-spa-parcels-explained.md
+++ b/website/blog/2018-06-19-single-spa-parcels-explained.md
@@ -11,19 +11,19 @@ And with the release of [version 4](https://github.com/single-spa/single-spa/rel
 
 ## Another way to do framework agnostic components?
 
-For those familiar with [web components](https://developer.mozilla.org/en-US/docs/Web/Web_Components) and [custom elements](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements), you may be wondering why a javascript library would try to do what browsers are starting natively to do.
+For those familiar with [web components](https://developer.mozilla.org/en-US/docs/Web/Web_Components) and [custom elements](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements), you may be wondering why a JavaScript library would try to do what browsers are starting natively to do.
 
 And as one of the contributors to the custom elements polyfill, let me be the first one to say that we did not make this decision lightly.
 
 If you’re interested in diving into the details, check out [One Company’s Relationship With Custom Elements](https://medium.com/canopy-tax/one-companys-relationship-with-custom-elements-d360baf3b253), which explains some of the difficulties we’ve been through with web components and custom elements.
 
-TLDR: React and some other frameworks don’t interop with custom elements very well. Additionally dealing with inner html, attributes vs properties, and customized builtins can be a pain.
+TLDR: React and some other frameworks don’t interop with custom elements very well. Additionally dealing with inner HTML, attributes vs properties, and customized builtins can be a pain.
 
 ## Okay but you haven’t told me what a single-spa parcel is
 
 A parcel is single-spa’s way of building a component in one framework and using it in another.
 
-To implement a parcel, just create a javascript object that has 3–4 functions on it. We call this javascript object a _parcel config_ and there are three required functions to implement: bootstrap, mount, and unmount. A fourth function, update, is optional.
+To implement a parcel, just create a JavaScript object that has 3–4 functions on it. We call this JavaScript object a _parcel config_ and there are three required functions to implement: bootstrap, mount, and unmount. A fourth function, update, is optional.
 
 Each of the functions will be called by single-spa at the right time, but the parcel config will control what happens. In other words, single-spa controls the “when,” but the parcel config controls the “what” and the “how.”
 

--- a/website/blog/2020-02-24-single-spa-5.md
+++ b/website/blog/2020-02-24-single-spa-5.md
@@ -48,7 +48,7 @@ We understand that single-spa is more than just a library - it is an architectur
 The videos currently cover the following topics:
 
 - What are Microfrontends?
-- In-browser vs build-time javascript modules
+- In-browser vs build-time JavaScript modules
 - Import Maps
 - Local Development with single-spa and import maps
 - Deploying Microfrontends / Continuous Integration (CI)

--- a/website/src/components/Errors/Codes/14.js
+++ b/website/src/components/Errors/Codes/14.js
@@ -17,10 +17,10 @@ export default function ErrorCode14(props) {
 
             navigateToUrl('/path')
 
-            // Or via html
+            // Or via HTML
             <a href="/path" onClick="singleSpaNavigate">Link</a>
 
-            // Or via jsx / templates
+            // Or via JSX / templates
             <a href="/path" onClick={navigateToUrl}>Link</a>
           `}
         </CodeSnippet>

--- a/website/src/components/Errors/Codes/22.js
+++ b/website/src/components/Errors/Codes/22.js
@@ -6,7 +6,7 @@ export default function ErrorCode22(props) {
     <>
       <h1>#22: Custom props must be an object</h1>
       <p>
-        Cannot register application '{props.getErrorCodeArg(0)}' because the customProps are not a plain javascript object.
+        Cannot register application '{props.getErrorCodeArg(0)}' because the customProps are not a plain JavaScript object.
       </p>
       <h2>To fix:</h2>
       <div>

--- a/website/src/components/Errors/Codes/30.js
+++ b/website/src/components/Errors/Codes/30.js
@@ -11,7 +11,7 @@ export default function ErrorCode30(props) {
       </p>
       <p>
         This problem is logged as a warning to the console, but is not thrown as an additional error. The reason it is logged is that
-        only javascript Error objects will provide a good stacktrace for you to debug the cause of the Error.
+        only JavaScript Error objects will provide a good stacktrace for you to debug the cause of the Error.
       </p>
       <h2>To fix:</h2>
       <div>

--- a/website/versioned_docs/version-4.x/api.md
+++ b/website/versioned_docs/version-4.x/api.md
@@ -211,7 +211,7 @@ console.log(status); // one of many statuses (see list below). e.g. MOUNTED
 			<div>
 				<dt>LOAD_ERROR</dt>
 				<dd>
-					The app's loading function returned a promise that rejected. This is often due to a network error attempting to download the javascript bundle for the application. Single-spa will retry loading the application after the user navigates away from the current route and then comes back to it.
+					The app's loading function returned a promise that rejected. This is often due to a network error attempting to download the JavaScript bundle for the application. Single-spa will retry loading the application after the user navigates away from the current route and then comes back to it.
 				</dd>
 			</div>
 		</dl>

--- a/website/versioned_docs/version-4.x/building-applications.md
+++ b/website/versioned_docs/version-4.x/building-applications.md
@@ -4,7 +4,7 @@ title: Building single-spa applications
 sidebar_label: single-spa applications
 ---
 
-A single-spa registered application is everything that a normal SPA is, except that it doesn't have an HTML page. In a single-spa world, your SPA contains many registered applications, where each has its own framework. Registered applications have their own client-side routing and their own frameworks/libraries. They render their own html and have full freedom to do whatever they want, whenever they are *mounted*. The concept of being *mounted* refers to whether a registered application is putting content on the DOM or not. What determines if a registered application is mounted is its [activity function](configuration#activity-function). Whenever a registered application is *not mounted*, it should remain completely dormant until mounted.
+A single-spa registered application is everything that a normal SPA is, except that it doesn't have an HTML page. In a single-spa world, your SPA contains many registered applications, where each has its own framework. Registered applications have their own client-side routing and their own frameworks/libraries. They render their own HTML and have full freedom to do whatever they want, whenever they are *mounted*. The concept of being *mounted* refers to whether a registered application is putting content on the DOM or not. What determines if a registered application is mounted is its [activity function](configuration#activity-function). Whenever a registered application is *not mounted*, it should remain completely dormant until mounted.
 
 ## Creating a registered application
 

--- a/website/versioned_docs/version-4.x/ecosystem-angular.md
+++ b/website/versioned_docs/version-4.x/ecosystem-angular.md
@@ -233,8 +233,8 @@ Run the following:
 npm run serve:single-spa
 ```
 
-This **will not** open up an html file, since single-spa applications all [share one html file](/docs/configuration.html). Instead, go to
-http://single-spa-playground.org and follow the instructions there to verify everything is working and for instructions on creating the shared html file.
+This **will not** open up an HTML file, since single-spa applications all [share one HTML file](/docs/configuration.html). Instead, go to
+http://single-spa-playground.org and follow the instructions there to verify everything is working and for instructions on creating the shared HTML file.
 
 ## Building
 Run `npm run build:single-spa`, which will create a `dist` directory with your compiled code.
@@ -284,7 +284,7 @@ The following options are available:
 
 - `bootstrapFunction`: (required) A function that is given custom props as an argument and returns a promise that resolves with a resolved Angular module that is bootstrapped. Usually, your implementation will look like this: `bootstrapFunction: (customProps) => platformBrowserDynamic().bootstrapModule()`.
   See [custom props documentation](https://single-spa.js.org/docs/building-applications.html#custom-props) for more info on the argument passed to the function.
-- `template`: (required) An html string that will be put into the DOM Element returned by `domElementGetter`. This template can be anything,
+- `template`: (required) An HTML string that will be put into the DOM Element returned by `domElementGetter`. This template can be anything,
   but it is recommended that you keeping it simple by making it only one Angular component. For example, `<app-root />` is recommended,
   but `<div><app-root /><span>Hello</span><another-component /></div>` is allowed. Note that `innerHTML` is used to put the template
   onto the DOM. Also note that when using multiple angular applications simultaneously, you will want to make sure that the component
@@ -397,7 +397,7 @@ import { assetUrl } from 'src/single-spa/asset-url';
 const imageUrl = assetUrl('yoshi.png')
 ```
 
-#### Within html templates
+#### Within HTML templates
 
 ##### Option 1
 
@@ -437,7 +437,7 @@ This is because single-spa applications have to all share an HTML file.
 have no impact on your single-spa build.
 
 #### Option 1
-Add the script tags directly into your [root html file](http://single-spa-playground.org/playground/html-file). This way is easiest.
+Add the script tags directly into your [root HTML file](http://single-spa-playground.org/playground/html-file). This way is easiest.
 The downside is that all of the scripts get loaded even for routes that don't need them. However, that is generally okay and this
 is the preferred way to do it.
 
@@ -446,7 +446,7 @@ If you want the scripts to only be loaded when needed, you can add a custom
 [bootstrap lifecycle](http://localhost:3000/docs/building-applications.html#bootstrap) to your code.
 
 Note that lazy loading these scripts can actually be worse for performance *if you always need them*, since
-they will start downloading later than if you put them right into the root html file.
+they will start downloading later than if you put them right into the root HTML file.
 
 ```ts
 // main.single-spa.ts
@@ -482,14 +482,14 @@ be loaded by single-spa-angular's webpack config, without you having to configur
 Your component styles will also be loaded like normal without you having to configure anything.
 
 ### Polyfills
-[Polyfills in your angular.json](https://angular.io/guide/browser-support) are javascript code that make your project work in older browsers,
+[Polyfills in your angular.json](https://angular.io/guide/browser-support) are JavaScript code that make your project work in older browsers,
 such as IE11.
 
 **The polyfills that you specify in your angular.json file will not be loaded automatically**. This is because we should only load
-polyfills once in the root html file, instead of once per application.
+polyfills once in the root HTML file, instead of once per application.
 
 To load polyfills, you'll need to follow the instructions in the [Angular documentation for non-CLI users](https://angular.io/guide/browser-support#polyfills-for-non-cli-users).
-Even if you are using Angular CLI, you will need to follow those instructions, since your [single-spa root html file](https://single-spa-playground.org/playground/html-file)
+Even if you are using Angular CLI, you will need to follow those instructions, since your [single-spa root HTML file](https://single-spa-playground.org/playground/html-file)
 is not using Angular CLI and that's where the polyfills need to go.
 
 If you're looking for a quick one-liner, try adding this line near the top of your index.html.

--- a/website/versioned_docs/version-4.x/ecosystem-angularjs.md
+++ b/website/versioned_docs/version-4.x/ecosystem-angularjs.md
@@ -87,11 +87,11 @@ All options are passed to single-spa-angularjs via the `opts` parameter when cal
 - `domElementGetter`: (optional) A function that takes in no arguments and returns a DOMElement. This dom element is where the angular
   application will be bootstrapped, mounted, and unmounted. If not provided, the default is to create a div and append it to `document.body`.
 - `mainAngularModule`: (required) A string that is the name of the angular module that will be bootstrapped by angular. See [angular docs](https://docs.angularjs.org/api/ng/function/angular.bootstrap) for `angular.bootstrap()`.
-- `uiRouter`: (optional) If you are using angular-ui-router, set this option to either `true` or to a string value. The string value will be the value of the ui-view html attribute. For example, `uiRouter: 'core'` will be `<div ui-view="core" />` whereas `uiRouter: true` turns into `<div ui-view />`.
+- `uiRouter`: (optional) If you are using angular-ui-router, set this option to either `true` or to a string value. The string value will be the value of the ui-view HTML attribute. For example, `uiRouter: 'core'` will be `<div ui-view="core" />` whereas `uiRouter: true` turns into `<div ui-view />`.
 - `preserveGlobal`: (optional) A boolean that defaults to false. Set if you want to keep angular on the global even after an app unmounts.
 - `elementId`: (optional) A string which will be used to identify the element appended to the DOM and bootstrapped by Angular.
 - `strictDi`: (optional - part of the bootstrap [config object](https://docs.angularjs.org/api/ng/function/angular.bootstrap#usage)) A boolean that defaults to false. Set if you want to enable StrictDi mode
-- `template`: (optional) An html string that will be inserted into the DOM when the app is mounted. The template goes inside of the element returned by domElementGetter. If not provided, no template will be inserted. When using angular-ui-router, you often do not need to use this since ui-router will be putting a template onto the dom for you.
+- `template`: (optional) An HTML string that will be inserted into the DOM when the app is mounted. The template goes inside of the element returned by domElementGetter. If not provided, no template will be inserted. When using angular-ui-router, you often do not need to use this since ui-router will be putting a template onto the dom for you.
 
 ## ES5 Example
 Check out [this example repo](https://github.com/joeldenning/single-spa-es5-angularjs)

--- a/website/versioned_docs/version-4.x/ecosystem-backbone.md
+++ b/website/versioned_docs/version-4.x/ecosystem-backbone.md
@@ -157,17 +157,17 @@ optional
 
 * `AppWithRequire` (required) : This parameter takes an object and expects below properties:
 	* `IsDataMain` (optional) : This parameter takes a boolean value and is used to specify whether require js will use `data-main` to load the app.
-	* `AppPath` (required) : This parameter takes a string value and specifies the path of javascript file, which is entry point of your application and will be booted up using RequireJs. The path is relative to BasePath.
+	* `AppPath` (required) : This parameter takes a string value and specifies the path of JavaScript file, which is entry point of your application and will be booted up using RequireJs. The path is relative to BasePath.
 	* `RequireJsPath` (required) : This parameter takes a string value and takes the path of the RequireJs file and is relative to BasePath.
-	* `DependenciesJsPaths` (optional) : This is an optional parameter takes an array of strings. It can be used to optionally provide a list of javascript path which you want to load in the browser.
+	* `DependenciesJsPaths` (optional) : This is an optional parameter takes an array of strings. It can be used to optionally provide a list of JavaScript paths which you want to load in the browser.
 
 * `AppWithBackboneJs` (optional) : This parameter takes an object and expects below properties:
-	* `AppPath` (required) : This parameter takes a string value and specifies the path of javascript file, which is entry point of your application and will be booted up using Backbone Js. The path is relative to BasePath.
+	* `AppPath` (required) : This parameter takes a string value and specifies the path of JavaScript file, which is entry point of your application and will be booted up using Backbone Js. The path is relative to BasePath.
 	* `BackboneJsPath` (required) : This parameter takes a string value and takes the path of the Backbone Js file and is relative to BasePath.
-	* `DependenciesJsPaths` (optional) : This is an optional parameter takes an array of strings. It can be used to optionally provide a list of javascript path which you want to load in the browser.
+	* `DependenciesJsPaths` (optional) : This is an optional parameter takes an array of strings. It can be used to optionally provide a list of JavaScript paths which you want to load in the browser.
 
 * `App` (optional) : This parameter takes an object and expects below properties:
-	* `AppPath` (required) : This parameter takes a string value and specifies the path of javascript file, which is production build of your backbone application. The path is relative to BasePath.
+	* `AppPath` (required) : This parameter takes a string value and specifies the path of the JavaScript file, which is the production build of your backbone application. The path is relative to BasePath.
 
 ### Note : Out of AppWithRequire, AppWithBackboneJs and  App only one is required
 

--- a/website/versioned_docs/version-4.x/ecosystem-ember.md
+++ b/website/versioned_docs/version-4.x/ecosystem-ember.md
@@ -63,7 +63,7 @@ export const unmount = emberLifecycles.unmount;
 ```
 
 ## Usage with ember cli
-For the most part, you can get applications that use [ember cli](https://ember-cli.com/) to work pretty seamlessly with single-spa. Maybe the biggest thing you'll have to worry about is that ember-cli assumes that it controls the entire html page, whereas a single-spa application does not. However, usually we can achieve equivalent behavior by just loading the vendor and app bundles into the html page dynamically, instead of baking them right into the html page. Below is a description of the known things you should do when setting up an ember-cli application with single-spa:
+For the most part, you can get applications that use [ember cli](https://ember-cli.com/) to work pretty seamlessly with single-spa. Maybe the biggest thing you'll have to worry about is that ember-cli assumes that it controls the entire HTML page, whereas a single-spa application does not. However, usually we can achieve equivalent behavior by just loading the vendor and app bundles into the HTML page dynamically, instead of baking them right into the HTML page. Below is a description of the known things you should do when setting up an ember-cli application with single-spa:
 
 First, since the ember cli only supports dependencies from bower, you'll need to do:
 
@@ -80,7 +80,7 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 module.exports = function(defaults) {
   let app = new EmberApp(defaults, {
     autoRun: false, // Set autoRun to false, because we only want the ember app to render to the DOM when single-spa tells it to.
-    storeConfigInMeta: false, // We're making a single-spa application, which doesn't exclusively own the html file. So we don't want to have to have a `<meta>` tag for the ember environment to be initialized.
+    storeConfigInMeta: false, // We're making a single-spa application, which doesn't exclusively own the HTML file. So we don't want to have to have a `<meta>` tag for the ember environment to be initialized.
 		fingerprint: {
 			customHash: null, // This is optional, just will make it easier for you to have the same url every time you do an ember build.
 		},

--- a/website/versioned_docs/version-4.x/ecosystem-html-web-components.md
+++ b/website/versioned_docs/version-4.x/ecosystem-html-web-components.md
@@ -4,7 +4,7 @@ title: single-spa-html
 sidebar_label: HTML / Web Components
 ---
 
-[single-spa-html](https://github.com/single-spa/single-spa-html) is a helper library for mounting raw html and web components as
+[single-spa-html](https://github.com/single-spa/single-spa-html) is a helper library for mounting raw HTML and web components as
 single-spa applications or parcels.
 
 ## Installation

--- a/website/versioned_docs/version-4.x/ecosystem-vue.md
+++ b/website/versioned_docs/version-4.x/ecosystem-vue.md
@@ -31,7 +31,7 @@ The CLI Plugin does the following for you:
 npm install --save single-spa-vue
 ```
 
-Alternatively, you can use  single-spa-vue by adding `<script src="https://unpkg.com/single-spa-vue"></script>` to your html file and
+Alternatively, you can use  single-spa-vue by adding `<script src="https://unpkg.com/single-spa-vue"></script>` to your HTML file and
 accessing the `singleSpaVue` global variable.
 
 ## Usage

--- a/website/versioned_docs/version-4.x/getting-started-overview.md
+++ b/website/versioned_docs/version-4.x/getting-started-overview.md
@@ -6,7 +6,7 @@ sidebar_label: Overview of single-spa
 
 ## JavaScript Microfrontends
 
-single-spa is a framework for bringing together multiple javascript microfrontends in a frontend application. Architecting your frontend using single-spa enables many benefits, such as:
+single-spa is a framework for bringing together multiple JavaScript microfrontends in a frontend application. Architecting your frontend using single-spa enables many benefits, such as:
 
 - [Use multiple frameworks](ecosystem.md#help-for-frameworks) on the same page [without page refreshing](building-applications.md)
   ([React](ecosystem-react.md), [AngularJS](ecosystem-angularjs.md), [Angular](ecosystem-angular.md), [Ember](ecosystem-ember.md), or whatever you're using)
@@ -27,10 +27,10 @@ It was born out of Canopy's desire to use React + react-router instead of being 
 
 single-spa apps consist of the following:
 
-1. [Applications](building-applications.md), each of which is an entire SPA itself (sort of). Each application can respond to url routing events and must know how to bootstrap, mount, and unmount itself from the DOM. The main difference between a traditional SPA and single-spa applications is that they must be able to coexist with other applications, and they do not each have their own html page.
+1. [Applications](building-applications.md), each of which is an entire SPA itself (sort of). Each application can respond to url routing events and must know how to bootstrap, mount, and unmount itself from the DOM. The main difference between a traditional SPA and single-spa applications is that they must be able to coexist with other applications, and they do not each have their own HTML page.
 
     For example, your React or Angular SPAs are applications. When active, they listen to url routing events and put content on the DOM. When inactive, they do not listen to url routing events and are totally removed from the DOM.
-2. A [single-spa-config](configuration), which is the html page _and_ the JavaScript that registers applications with single-spa. Each application is registered with three things:
+2. A [single-spa-config](configuration), which is the HTML page _and_ the JavaScript that registers applications with single-spa. Each application is registered with three things:
     - A name
     - A function to load the application's code
     - A function that determines when the application is active/inactive
@@ -73,7 +73,7 @@ For a full example, check out [this simple webpack example](https://github.com/j
 
 To create a single-spa application, you will need to do three things:
 
-1. Create an html file.
+1. Create an HTML file.
 
 ```html
 <html>
@@ -90,7 +90,7 @@ import * as singleSpa from 'single-spa';
 
 const appName = 'app1';
 
-/* The loading function is a function that returns a promise that resolves with the javascript application module.
+/* The loading function is a function that returns a promise that resolves with the JavaScript application module.
  * The purpose of it is to facilitate lazy loading -- single-spa will not download the code for a application until it needs to.
  * In this example, import() is supported in webpack and returns a Promise, but single-spa works with any loading function that returns a Promise.
  */

--- a/website/versioned_docs/version-4.x/migrating-angularJS-tutorial.md
+++ b/website/versioned_docs/version-4.x/migrating-angularJS-tutorial.md
@@ -30,7 +30,7 @@ Run `grunt` in the root directory to fire up a server at `http://localhost:8080`
 
 ## Step One: Create a single-spa config
 
-The single spa config consists of all code that is not part of a [registered application](https://single-spa.js.org/docs/configuration.html#registeringapplications). Ideally, this only includes an html file and a javascript file that registers single-spa applications. It is best practice to keep your single spa config as small as possible and to simply defer to single-spa to manage all of the applications. The single spa config should not be doing client-side html rendering nor should it be responding to routing events such as `hashchange` or `popstate`. Instead, all of that functionality should be taken care of either by single-spa itself or by a single-spa application.
+The single spa config consists of all code that is not part of a [registered application](https://single-spa.js.org/docs/configuration.html#registeringapplications). Ideally, this only includes an HTML file and a JavaScript file that registers single-spa applications. It is best practice to keep your single spa config as small as possible and to simply defer to single-spa to manage all of the applications. The single spa config should not be doing client-side HTML rendering nor should it be responding to routing events such as `hashchange` or `popstate`. Instead, all of that functionality should be taken care of either by single-spa itself or by a single-spa application.
 
 It is required to [register applications](https://single-spa.js.org/docs/configuration.html#registering-applications) with single-spa. This enables single-spa to know how and when to bootstrap, mount and unmount an application. We will be creating a `single-spa.config.js` file to house all of our single-spa logic.
 
@@ -42,7 +42,7 @@ touch public/single-spa.config.js
 
 ### a) importing without using import
 
-Since we are using an older version of Angular, and we do not have access to babel, we cannot use `import` or even `require()` to obtain access to the single-spa library. One way around this is to include a `<script>` tag in the project's html file which will provide us access to the library. Single-spa is hosted on [https://unpkg.com/](https://unpkg.com/) and when called, creates a global variable.
+Since we are using an older version of Angular, and we do not have access to babel, we cannot use `import` or even `require()` to obtain access to the single-spa library. One way around this is to include a `<script>` tag in the project's HTML file which will provide us access to the library. Single-spa is hosted on [https://unpkg.com/](https://unpkg.com/) and when called, creates a global variable.
 
 In `public/index.html`, add the following script tag at the bottom of the `<head>`
 
@@ -55,7 +55,7 @@ In `public/index.html`, add the following script tag at the bottom of the `<head
 
 ### b) Connect the config file
 
-To get single-spa connected, we will need to include a script tag connecting the html file to single-spa.config.js (we will be building the single-spa.config.js file in the next step).
+To get single-spa connected, we will need to include a script tag connecting the HTML file to single-spa.config.js (we will be building the single-spa.config.js file in the next step).
 
 Add the following `<script>` at the bottom of `index.html`
 
@@ -99,7 +99,7 @@ The third argument, `activityFunction`, must be a pure function. The function is
 
 Since we have registered our application, single-spa will be listening for the application to `bootstrap` and `mount`. We can use the [single-spa-angularjs](ecosystem-angularjs.md) helper library which will handle generic lifecycle hooks (bootstrap, mount and unmount) for registered angularjs applications.
 
-To gain access to the `single-spa-angularjs` library, we will need to include another `<script>` tag in our html file.
+To gain access to the `single-spa-angularjs` library, we will need to include another `<script>` tag in our HTML file.
 
 Add the following in `public/index.html` at the very bottom of the `<head>`.
 
@@ -150,7 +150,7 @@ window.singleSpa.registerApplication(
 window.singleSpa.start();
 ```
 
-## Step Four: Adjust your html file
+## Step Four: Adjust your HTML file
 
 Since most existing SPAs are used to having control of an *index.html* file for their css, fonts, third party script-tags, etc., it's likely that you'll have to do some work to make sure all of those keep on working when your SPA becomes an html-less application.
 
@@ -158,7 +158,7 @@ In this case, we are going to have to make a few adjustments to the current *ind
 
 ### a) Prevent auto bootstrapping
 
-Currently, our *index.html* contains two hurdles we will need to overcome to allow single-spa to control the DOM. The first is the auto-bootstrap directive [`ng-app`](https://docs.angularjs.org/api/ng/directive/ngApp) at the top of the html file. If left in the html file, `ng-app` will force the entire application to automatically bootstrap and render, overriding the single-spa lifecycle functions. To fix this, we simply need to remove `ng-app` from the html file and then allow `single-spa-angularjs` to call the `bootstrap` function instead (recall that we set this up in [Step Three](migrating-angularJS-tutorial.md#step-three-setup-lifecycle-functions)).
+Currently, our *index.html* contains two hurdles we will need to overcome to allow single-spa to control the DOM. The first is the auto-bootstrap directive [`ng-app`](https://docs.angularjs.org/api/ng/directive/ngApp) at the top of the HTML file. If left in the HTML file, `ng-app` will force the entire application to automatically bootstrap and render, overriding the single-spa lifecycle functions. To fix this, we simply need to remove `ng-app` from the HTML file and then allow `single-spa-angularjs` to call the `bootstrap` function instead (recall that we set this up in [Step Three](migrating-angularJS-tutorial.md#step-three-setup-lifecycle-functions)).
 
 In *index.html* remove `ng-app="AngularDrumMachine`.
 
@@ -172,7 +172,7 @@ In *index.html* remove `ng-app="AngularDrumMachine`.
 
 ### b) Create a Template
 
-The second challenge is that the *index.html* currently holds the entire application template. Since html will automatically render anything in the file, we will need to pull all of the SPAs logic out of the html file and replace it with a new `<div />` containing the `id` single-spa will use to mount the application. To do this, we will create a new template that we can then provide to the `single-spa-angularjs` lifecycle function.
+The second challenge is that the *index.html* currently holds the entire application template. Since HTML will automatically render anything in the file, we will need to pull all of the SPAs logic out of the HTML file and replace it with a new `<div />` containing the `id` single-spa will use to mount the application. To do this, we will create a new template that we can then provide to the `single-spa-angularjs` lifecycle function.
 
 Create a new directory inside of *public/assets* called *templates/*. Then create a new template called *display-machine.template.html*.
 
@@ -266,7 +266,7 @@ The new template *display-machine.template.html* should look like this:
 
 ### c) Create a Directive
 
-Per the [AngularJS conventions](https://docs.angularjs.org/guide/directive), we will need to create a directive in order to "compile" our new html template. Let's start by creating a new *directives/* folder inside *public/app* to house a new *display-machine.directive.js*
+Per the [AngularJS conventions](https://docs.angularjs.org/guide/directive), we will need to create a directive in order to "compile" our new HTML template. Let's start by creating a new *directives/* folder inside *public/app* to house a new *display-machine.directive.js*
 
 ```bash
 mkdir public/app/directives

--- a/website/versioned_docs/version-4.x/migrating-existing-spas.md
+++ b/website/versioned_docs/version-4.x/migrating-existing-spas.md
@@ -9,13 +9,13 @@ need to do three things:
 
 1. Create a [single spa config](configuration)
 1. [Convert your SPA or SPAs to be registered applications](#converting-spas-into-registered-applications)
-1. Adjust your html file so that your single spa config is the new boss in town.
+1. Adjust your HTML file so that your single spa config is the new boss in town.
    See [docs](configuration#indexhtml-file).
 
 ## Converting SPAs into registered applications
 Your existing SPAs, whether they be Angular, React, or something else, probably are
 not used to unmounting themselves from the DOM. Also, they probably have had the luxury
-of controlling the entire html page themselves, instead of being purely javascript applications
+of controlling the entire HTML page themselves, instead of being purely JavaScript applications
 that don't have sole control over `<script>` tags and `<link>` tags. So in order to convert them
 into single-spa registered applications, they will need to overcome those obstacles while implementing
 lifecycle functions.
@@ -33,5 +33,5 @@ Since existing SPAs are used to having an index.html file for their css, fonts,
 third party script-tags, etc., it's likely that you'll have to do some work
 to make sure all of those keep on working when your SPA becomes an html-less [
 application](building-applications.md). It is best to try to put all that
-you can into the javascript bundle, but your escape hatch is to put the things
+you can into the JavaScript bundle, but your escape hatch is to put the things
 you need into your [single spa config](configuration).

--- a/website/versioned_docs/version-4.x/migrating-react-tutorial.md
+++ b/website/versioned_docs/version-4.x/migrating-react-tutorial.md
@@ -21,7 +21,7 @@ Run `yarn start` from the root directory to fire up the server at [http://localh
 
 ## Step One: Set up the single-spa config
 
-The __single-spa config__ consists of all code that is not part of a [registered application](configuration#registeringapplications). Ideally, this only includes an html file and a javascript file that registers single-spa applications. It is best practice to keep your single spa config as small as possible and to simply defer to single-spa to manage all of the applications.
+The __single-spa config__ consists of all code that is not part of a [registered application](configuration#registeringapplications). Ideally, this only includes an HTML file and a JavaScript file that registers single-spa applications. It is best practice to keep your single spa config as small as possible and to simply defer to single-spa to manage all of the applications.
 
 Usually, when using [webpack](https://webpack.js.org/) with React, we recommend setting your __single-spa config__ as the entry point in your *webpack.config.js* ([see also the "Setup Webpack" example](starting-from-scratch.md#1b-setup-webpack)). However, this application was built using [create-react-app](https://github.com/facebook/create-react-app), so we don't have access to the *webpack.config.js* without [ejecting](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#npm-run-eject).
 
@@ -91,7 +91,7 @@ touch src/root.app.js
 
 During this process, we need to establish a `rootComponent`, which is the top level React component to be rendered. In this case *src/containers/App.js* has already been designated as the top level component. If you recall, we removed this from the *index.js* file so we could set up our __single-spa config__.
 
-Finally, we will use the `domElementGetter()` function to return a DOMElement where the application will be bootstrapped, mounted, and unmounted. Notice that our SPA already has an html file in the *public/* folder containing a `<div />` with and id of `root`.
+Finally, we will use the `domElementGetter()` function to return a DOMElement where the application will be bootstrapped, mounted, and unmounted. Notice that our SPA already has an HTML file in the *public/* folder containing a `<div />` with and id of `root`.
 
 Set up the registered application lifecycle functions by adding the following to *src/root.app.js*:
 

--- a/website/versioned_docs/version-4.x/parcels-api.md
+++ b/website/versioned_docs/version-4.x/parcels-api.md
@@ -13,7 +13,7 @@ They both return a [parcel object](parcels-api.md#parcel-object). The parcel obj
 
 ### Parcel Props
 
-When mounting a parcel the second argument is props, a javascript object of properties to be passed to the parcel. This object must have a domElement prop, which is the dom node that the parcel will mount into.
+When mounting a parcel the second argument is props, a JavaScript object of properties to be passed to the parcel. This object must have a domElement prop, which is the dom node that the parcel will mount into.
 
 ```js
 const parcelProps = {

--- a/website/versioned_docs/version-4.x/separating-applications.md
+++ b/website/versioned_docs/version-4.x/separating-applications.md
@@ -4,7 +4,7 @@ title: Splitting up applications
 sidebar_label: Splitting applications
 ---
 
-In a large, microserviced system, your root single-spa configuration and each of the applications should probably have its own git repository. How to do that in a javascript project isn't necessarily clear, so some options are listed below.
+In a large, microserviced system, your root single-spa configuration and each of the applications should probably have its own git repository. How to do that in a JavaScript project isn't necessarily clear, so some options are listed below.
 
 Since single-spa is a framework that helps with organizational scaling, it is important to figure out how to split out and separate applications from each other so that developers and teams can work on the applications without interfering one another.
 
@@ -12,7 +12,7 @@ Most interpretations of microservice architecture encourage separate code reposi
 
 #### Option 1: One code repo, one build
 
-The simplest approach for using single-spa is to have one code repository with everything in it. Typically, you would have a single package.json with a single webpack config that produces a bundle that can be included in an html file with a `<script>` tag.
+The simplest approach for using single-spa is to have one code repository with everything in it. Typically, you would have a single package.json with a single webpack config that produces a bundle that can be included in an HTML file with a `<script>` tag.
 
 Advantages:
 
@@ -46,12 +46,12 @@ Disadvantages:
 
 Create a root application which can allow single-spa applications to deploy themselves separately. To do so,
 create a manifest file that the single-spa applications update during their deployment process, which controls
-which versions of the single-spa applications are "live". Then change which javascript file is loaded based on the manifest.
+which versions of the single-spa applications are "live". Then change which JavaScript file is loaded based on the manifest.
 
-Changing which javascript file is loaded for each child application can be done in many ways.
+Changing which JavaScript file is loaded for each child application can be done in many ways.
 
 1. Web server: have your webserver create a dynamic script tag for the "live" version of each single-spa application.
-2. Use a [module loader](https://www.jvandemo.com/a-10-minute-primer-to-javascript-modules-module-formats-module-loaders-and-module-bundlers/) such as [SystemJS](https://github.com/systemjs/systemjs) that can download and execute javascript code in the browser from dynamic urls.
+2. Use a [module loader](https://www.jvandemo.com/a-10-minute-primer-to-javascript-modules-module-formats-module-loaders-and-module-bundlers/) such as [SystemJS](https://github.com/systemjs/systemjs) that can download and execute JavaScript code in the browser from dynamic urls.
 
 #### Comparison
 

--- a/website/versioned_docs/version-4.x/single-spa-config.md
+++ b/website/versioned_docs/version-4.x/single-spa-config.md
@@ -6,7 +6,7 @@ sidebar_label: single-spa config
 
 The single spa root config consists of the following:
 1. The root HTML file that is shared by all single-spa applications.
-2. the javascript that calls [`singleSpa.registerApplication()`](/docs/api.html#registerapplication).
+2. The JavaScript that calls [`singleSpa.registerApplication()`](/docs/api.html#registerapplication).
 
 Your root config exists only to start up the single-spa applications.
 

--- a/website/versioned_docs/version-4.x/starting-from-scratch.md
+++ b/website/versioned_docs/version-4.x/starting-from-scratch.md
@@ -163,9 +163,9 @@ The last step in our project set up is to include a couple scripts in our packag
 },
 ```
 
-## 2. Create the html file
+## 2. Create the HTML file
 
-Our goal in this step will be to create a __single-spa config__. The single-spa config file is where your applications are initialized, and an html page will request this config.
+Our goal in this step will be to create a __single-spa config__. The single-spa config file is where your applications are initialized, and an HTML page will request this config.
 
 You’ll want to keep your single-spa config as small as possible since it is the master controller and could easily become a maintenance bottleneck. You don’t want to be constantly changing both the single-spa config and the child applications.
 
@@ -542,7 +542,7 @@ registerApplication(
 
 > __Hint__
 >
-> Don't forget to define a corresponding mount point for _every newly registered application_ in your root html file. We did this already in [Step 2.a](starting-from-scratch.md#2a-create-indexhtml) so just remember to do so for each new application in the future.
+> Don't forget to define a corresponding mount point for _every newly registered application_ in your root HTML file. We did this already in [Step 2.a](starting-from-scratch.md#2a-create-indexhtml) so just remember to do so for each new application in the future.
 
 ### 5.b Setup NavBar
 

--- a/website/versioned_docs/version-5.x/api.md
+++ b/website/versioned_docs/version-5.x/api.md
@@ -277,7 +277,7 @@ console.log(status); // one of many statuses (see list below). e.g. MOUNTED
 			<div>
 				<dt>LOAD_ERROR</dt>
 				<dd>
-					The app's loading function returned a promise that rejected. This is often due to a network error attempting to download the javascript bundle for the application. Single-spa will retry loading the application after the user navigates away from the current route and then comes back to it.
+					The app's loading function returned a promise that rejected. This is often due to a network error attempting to download the JavaScript bundle for the application. Single-spa will retry loading the application after the user navigates away from the current route and then comes back to it.
 				</dd>
 			</div>
 		</dl>

--- a/website/versioned_docs/version-5.x/building-applications.md
+++ b/website/versioned_docs/version-5.x/building-applications.md
@@ -4,7 +4,7 @@ title: Building single-spa applications
 sidebar_label: single-spa applications
 ---
 
-A single-spa registered application is everything that a normal SPA is, except that it doesn't have an HTML page. In a single-spa world, your SPA contains many registered applications, where each has its own framework. Registered applications have their own client-side routing and their own frameworks/libraries. They render their own html and have full freedom to do whatever they want, whenever they are *mounted*. The concept of being *mounted* refers to whether a registered application is putting content on the DOM or not. What determines if a registered application is mounted is its [activity function](configuration#activity-function). Whenever a registered application is *not mounted*, it should remain completely dormant until mounted.
+A single-spa registered application is everything that a normal SPA is, except that it doesn't have an HTML page. In a single-spa world, your SPA contains many registered applications, where each has its own framework. Registered applications have their own client-side routing and their own frameworks/libraries. They render their own HTML and have full freedom to do whatever they want, whenever they are *mounted*. The concept of being *mounted* refers to whether a registered application is putting content on the DOM or not. What determines if a registered application is mounted is its [activity function](configuration#activity-function). Whenever a registered application is *not mounted*, it should remain completely dormant until mounted.
 
 ## Creating a registered application
 

--- a/website/versioned_docs/version-5.x/ecosystem-angular.md
+++ b/website/versioned_docs/version-5.x/ecosystem-angular.md
@@ -243,8 +243,8 @@ Run the following:
 npm run serve:single-spa
 ```
 
-This **will not** open up an html file, since single-spa applications all [share one html file](/docs/configuration.html). Instead, go to
-http://single-spa-playground.org and follow the instructions there to verify everything is working and for instructions on creating the shared html file.
+This **will not** open up an HTML file, since single-spa applications all [share one html file](/docs/configuration.html). Instead, go to
+http://single-spa-playground.org and follow the instructions there to verify everything is working and for instructions on creating the shared HTML file.
 
 ## Building
 Run `npm run build:single-spa`, which will create a `dist` directory with your compiled code.
@@ -353,7 +353,7 @@ The following options are available:
 
 - `bootstrapFunction`: (required) A function that is given custom props as an argument and returns a promise that resolves with a resolved Angular module that is bootstrapped. Usually, your implementation will look like this: `bootstrapFunction: (customProps) => platformBrowserDynamic().bootstrapModule()`.
   See [custom props documentation](https://single-spa.js.org/docs/building-applications.html#custom-props) for more info on the argument passed to the function.
-- `template`: (required) An html string that will be put into the DOM Element returned by `domElementGetter`. This template can be anything,
+- `template`: (required) An HTML string that will be put into the DOM Element returned by `domElementGetter`. This template can be anything,
   but it is recommended that you keeping it simple by making it only one Angular component. For example, `<app-root />` is recommended,
   but `<div><app-root /><span>Hello</span><another-component /></div>` is allowed. Note that `innerHTML` is used to put the template
   onto the DOM. Also note that when using multiple angular applications simultaneously, you will want to make sure that the component
@@ -471,7 +471,7 @@ import { assetUrl } from 'src/single-spa/asset-url';
 const imageUrl = assetUrl('yoshi.png')
 ```
 
-#### Within html templates
+#### Within HTML templates
 
 ##### Option 1
 
@@ -507,7 +507,7 @@ This is because single-spa applications have to all share an HTML file.
 have no impact on your single-spa build.
 
 #### Option 1
-Add the script tags directly into your [root html file](http://single-spa-playground.org/playground/html-file). This way is easiest.
+Add the script tags directly into your [root HTML file](http://single-spa-playground.org/playground/html-file). This way is easiest.
 The downside is that all of the scripts get loaded even for routes that don't need them. However, that is generally okay and this
 is the preferred way to do it.
 
@@ -516,7 +516,7 @@ If you want the scripts to only be loaded when needed, you can add a custom
 [bootstrap lifecycle](http://localhost:3000/docs/building-applications.html#bootstrap) to your code.
 
 Note that lazy loading these scripts can actually be worse for performance *if you always need them*, since
-they will start downloading later than if you put them right into the root html file.
+they will start downloading later than if you put them right into the root HTML file.
 
 ```ts
 // main.single-spa.ts
@@ -564,14 +564,14 @@ be loaded by single-spa-angular's webpack config, without you having to configur
 Your component styles will also be loaded like normal without you having to configure anything.
 
 ### Polyfills
-[Polyfills in your angular.json](https://angular.io/guide/browser-support) are javascript code that make your project work in older browsers,
+[Polyfills in your angular.json](https://angular.io/guide/browser-support) are JavaScript code that make your project work in older browsers,
 such as IE11.
 
 **The polyfills that you specify in your angular.json file will not be loaded automatically**. This is because we should only load
-polyfills once in the root html file, instead of once per application.
+polyfills once in the root HTML file, instead of once per application.
 
 To load polyfills, you'll need to follow the instructions in the [Angular documentation for non-CLI users](https://angular.io/guide/browser-support#polyfills-for-non-cli-users).
-Even if you are using Angular CLI, you will need to follow those instructions, since your [single-spa root html file](https://single-spa-playground.org/playground/html-file)
+Even if you are using Angular CLI, you will need to follow those instructions, since your [single-spa root HTML file](https://single-spa-playground.org/playground/html-file)
 is not using Angular CLI and that's where the polyfills need to go.
 
 If you're looking for a quick one-liner, try adding this line near the top of your index.html.
@@ -596,7 +596,7 @@ If you need to support IE11 or older, do the following:
 
 It's possible to develop Angular applications that don't rely on `zone.js` library, these applications are called _zone-less_. You have to run change detection manually in _zone-less_ applications through `ApplicationRef.tick()` or `ChangeDetectorRef.detectChanges()`. You can find more info in [Angular NoopZone docs](https://angular.io/guide/zone#noopzone).
 
-The point is that you do not need to load `zone.js` library in your root html file. As Angular docs mention that you should have a comprehensive knowledge of change detection to develop such applications. Let's start by _nooping_ zone when bootstrapping module:
+The point is that you do not need to load `zone.js` library in your root HTML file. As Angular docs mention that you should have a comprehensive knowledge of change detection to develop such applications. Let's start by _nooping_ zone when bootstrapping module:
 
 ```ts
 import { singleSpaAngular } from 'single-spa-angular';

--- a/website/versioned_docs/version-5.x/ecosystem-angularjs.md
+++ b/website/versioned_docs/version-5.x/ecosystem-angularjs.md
@@ -92,11 +92,11 @@ All options are passed to single-spa-angularjs via the `opts` parameter when cal
 - `domElementGetter`: (optional) A function that takes in the `props` parameter and returns a DOMElement. This dom element is where the angular
   application will be bootstrapped, mounted, and unmounted. If not provided, the default is to create a div and append it to `document.body`.
 - `mainAngularModule`: (required) A string that is the name of the angular module that will be bootstrapped by angular. See [angular docs](https://docs.angularjs.org/api/ng/function/angular.bootstrap) for `angular.bootstrap()`.
-- `uiRouter`: (optional) If you are using angular-ui-router, set this option to either `true` or to a string value. The string value will be the value of the ui-view html attribute. For example, `uiRouter: 'core'` will be `<div ui-view="core" />` whereas `uiRouter: true` turns into `<div ui-view />`.
+- `uiRouter`: (optional) If you are using angular-ui-router, set this option to either `true` or to a string value. The string value will be the value of the ui-view HTML attribute. For example, `uiRouter: 'core'` will be `<div ui-view="core" />` whereas `uiRouter: true` turns into `<div ui-view />`.
 - `preserveGlobal`: (optional) A boolean that defaults to false. Set if you want to keep angular on the global even after an app unmounts.
 - `elementId`: (optional) A string which will be used to identify the element appended to the DOM and bootstrapped by Angular.
 - `strictDi`: (optional - part of the bootstrap [config object](https://docs.angularjs.org/api/ng/function/angular.bootstrap#usage)) A boolean that defaults to false. Set if you want to enable StrictDi mode
-- `template`: (optional) An html string that will be inserted into the DOM when the app is mounted. The template goes inside of the element returned by domElementGetter. If not provided, no template will be inserted. When using angular-ui-router, you often do not need to use this since ui-router will be putting a template onto the dom for you.
+- `template`: (optional) An HTML string that will be inserted into the DOM when the app is mounted. The template goes inside of the element returned by domElementGetter. If not provided, no template will be inserted. When using angular-ui-router, you often do not need to use this since ui-router will be putting a template onto the dom for you.
 
 ## Custom Props
 

--- a/website/versioned_docs/version-5.x/ecosystem-backbone.md
+++ b/website/versioned_docs/version-5.x/ecosystem-backbone.md
@@ -157,17 +157,17 @@ optional
 
 * `AppWithRequire` (required) : This parameter takes an object and expects below properties:
 	* `IsDataMain` (optional) : This parameter takes a boolean value and is used to specify whether require js will use `data-main` to load the app.
-	* `AppPath` (required) : This parameter takes a string value and specifies the path of javascript file, which is entry point of your application and will be booted up using RequireJs. The path is relative to BasePath.
+	* `AppPath` (required) : This parameter takes a string value and specifies the path of the JavaScript file, which is entry point of your application and will be booted up using RequireJs. The path is relative to BasePath.
 	* `RequireJsPath` (required) : This parameter takes a string value and takes the path of the RequireJs file and is relative to BasePath.
-	* `DependenciesJsPaths` (optional) : This is an optional parameter takes an array of strings. It can be used to optionally provide a list of javascript path which you want to load in the browser.
+	* `DependenciesJsPaths` (optional) : This is an optional parameter takes an array of strings. It can be used to optionally provide a list of JavaScript paths which you want to load in the browser.
 
 * `AppWithBackboneJs` (optional) : This parameter takes an object and expects below properties:
-	* `AppPath` (required) : This parameter takes a string value and specifies the path of javascript file, which is entry point of your application and will be booted up using Backbone Js. The path is relative to BasePath.
+	* `AppPath` (required) : This parameter takes a string value and specifies the path of the JavaScript file, which is entry point of your application and will be booted up using Backbone Js. The path is relative to BasePath.
 	* `BackboneJsPath` (required) : This parameter takes a string value and takes the path of the Backbone Js file and is relative to BasePath.
-	* `DependenciesJsPaths` (optional) : This is an optional parameter takes an array of strings. It can be used to optionally provide a list of javascript path which you want to load in the browser.
+	* `DependenciesJsPaths` (optional) : This is an optional parameter takes an array of strings. It can be used to optionally provide a list of JavaScript paths which you want to load in the browser.
 
 * `App` (optional) : This parameter takes an object and expects below properties:
-	* `AppPath` (required) : This parameter takes a string value and specifies the path of javascript file, which is production build of your backbone application. The path is relative to BasePath.
+	* `AppPath` (required) : This parameter takes a string value and specifies the path of the JavaScript file, which is the production build of your backbone application. The path is relative to BasePath.
 
 ### Note : Out of AppWithRequire, AppWithBackboneJs and  App only one is required
 

--- a/website/versioned_docs/version-5.x/ecosystem-ember.md
+++ b/website/versioned_docs/version-5.x/ecosystem-ember.md
@@ -63,7 +63,7 @@ export const unmount = emberLifecycles.unmount;
 ```
 
 ## Usage with ember cli
-For the most part, you can get applications that use [ember cli](https://ember-cli.com/) to work pretty seamlessly with single-spa. Maybe the biggest thing you'll have to worry about is that ember-cli assumes that it controls the entire html page, whereas a single-spa application does not. However, usually we can achieve equivalent behavior by just loading the vendor and app bundles into the html page dynamically, instead of baking them right into the html page. Below is a description of the known things you should do when setting up an ember-cli application with single-spa:
+For the most part, you can get applications that use [ember cli](https://ember-cli.com/) to work pretty seamlessly with single-spa. Maybe the biggest thing you'll have to worry about is that ember-cli assumes that it controls the entire HTML page, whereas a single-spa application does not. However, usually we can achieve equivalent behavior by just loading the vendor and app bundles into the HTML page dynamically, instead of baking them right into the HTML page. Below is a description of the known things you should do when setting up an ember-cli application with single-spa:
 
 First, since the ember cli only supports dependencies from bower, you'll need to do:
 
@@ -80,7 +80,7 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 module.exports = function(defaults) {
   let app = new EmberApp(defaults, {
     autoRun: false, // Set autoRun to false, because we only want the ember app to render to the DOM when single-spa tells it to.
-    storeConfigInMeta: false, // We're making a single-spa application, which doesn't exclusively own the html file. So we don't want to have to have a `<meta>` tag for the ember environment to be initialized.
+    storeConfigInMeta: false, // We're making a single-spa application, which doesn't exclusively own the HTML file. So we don't want to have to have a `<meta>` tag for the ember environment to be initialized.
 		fingerprint: {
 			customHash: null, // This is optional, just will make it easier for you to have the same url every time you do an ember build.
 		},

--- a/website/versioned_docs/version-5.x/ecosystem-html-web-components.md
+++ b/website/versioned_docs/version-5.x/ecosystem-html-web-components.md
@@ -4,7 +4,7 @@ title: single-spa-html
 sidebar_label: HTML / Web Components
 ---
 
-[single-spa-html](https://github.com/single-spa/single-spa-html) is a helper library for mounting raw html and web components as
+[single-spa-html](https://github.com/single-spa/single-spa-html) is a helper library for mounting raw HTML and web components as
 single-spa applications or parcels.
 
 ## Installation

--- a/website/versioned_docs/version-5.x/ecosystem-vue.md
+++ b/website/versioned_docs/version-5.x/ecosystem-vue.md
@@ -37,7 +37,7 @@ The CLI Plugin does the following for you:
 npm install --save single-spa-vue
 ```
 
-Alternatively, you can use single-spa-vue by adding `<script src="https://unpkg.com/single-spa-vue"></script>` to your html file and
+Alternatively, you can use single-spa-vue by adding `<script src="https://unpkg.com/single-spa-vue"></script>` to your HTML file and
 accessing the `singleSpaVue` global variable.
 
 ## Usage

--- a/website/versioned_docs/version-5.x/faq.md
+++ b/website/versioned_docs/version-5.x/faq.md
@@ -14,7 +14,7 @@ The applications can all be written in the same framework, or they can be implem
 Yes, here is [the documentation for our recommended setup](/docs/recommended-setup/).
 
 ## Should I have a parent/root app and children apps?
-No. We strongly encourage that your single-spa-config or root application does not use any javascript ui-frameworks (React, Angular, Angularjs, Vue, etc). In our experience a plain javascript module is best for the single-spa-config and only the registered applications actually use ui-frameworks (angular, react, vue, etc). 
+No. We strongly encourage that your single-spa-config or root application does not use any JavaScript UI frameworks (React, Angular, Angularjs, Vue, etc). In our experience a plain JavaScript module is best for the single-spa-config and only the registered applications actually use UI frameworks (Angular, React, Vue, etc). 
 
 Why? You end up creating a structure that has all the disadvantages of microservices without any of the advantages: your apps are now coupled together and you have to change multiple apps at the same time in order to make updates. Good microservices are completely **independent**, and this pattern breaks that.
 

--- a/website/versioned_docs/version-5.x/getting-started-overview.md
+++ b/website/versioned_docs/version-5.x/getting-started-overview.md
@@ -8,7 +8,7 @@ sidebar_label: Overview of single-spa
 
 [Join the chat on Slack](https://join.slack.com/t/single-spa/shared_invite/enQtODAwNTIyMzc4OTE1LWUxMTUwY2M1MTY0ZGMzOTUzMGNkMzI1NzRiYzYwOWM1MTEzZDM1NDAyNWM3ZmViOTAzZThkMDcwMWZmNTFmMWQ)
 
-single-spa is a framework for bringing together multiple javascript microfrontends in a frontend application. Architecting your frontend using single-spa enables many benefits, such as:
+single-spa is a framework for bringing together multiple JavaScript microfrontends in a frontend application. Architecting your frontend using single-spa enables many benefits, such as:
 
 - [Use multiple frameworks](ecosystem.md#help-for-frameworks) on the same page [without page refreshing](building-applications.md)
   ([React](ecosystem-react.md), [AngularJS](ecosystem-angularjs.md), [Angular](ecosystem-angular.md), [Ember](ecosystem-ember.md), or whatever you're using)
@@ -27,10 +27,10 @@ It was born out of Canopy's desire to use React + react-router instead of being 
 
 single-spa apps consist of the following:
 
-1. [Applications](building-applications.md), each of which is an entire SPA itself (sort of). Each application can respond to url routing events and must know how to bootstrap, mount, and unmount itself from the DOM. The main difference between a traditional SPA and single-spa applications is that they must be able to coexist with other applications, and they do not each have their own html page.
+1. [Applications](building-applications.md), each of which is an entire SPA itself (sort of). Each application can respond to url routing events and must know how to bootstrap, mount, and unmount itself from the DOM. The main difference between a traditional SPA and single-spa applications is that they must be able to coexist with other applications, and they do not each have their own HTML page.
 
     For example, your React or Angular SPAs are applications. When active, they listen to url routing events and put content on the DOM. When inactive, they do not listen to url routing events and are totally removed from the DOM.
-2. A [single-spa-config](configuration), which is the html page _and_ the JavaScript that registers applications with single-spa. Each application is registered with three things:
+2. A [single-spa-config](configuration), which is the HTML page _and_ the JavaScript that registers applications with single-spa. Each application is registered with three things:
     - A name
     - A function to load the application's code
     - A function that determines when the application is active/inactive
@@ -91,7 +91,7 @@ import * as singleSpa from 'single-spa';
 
 const name = 'app1';
 
-/* The app can be a resolved application or a function that returns a promise that resolves with the javascript application module.
+/* The app can be a resolved application or a function that returns a promise that resolves with the JavaScript application module.
  * The purpose of it is to facilitate lazy loading -- single-spa will not download the code for a application until it needs to.
  * In this example, import() is supported in webpack and returns a Promise, but single-spa works with any loading function that returns a Promise.
  */

--- a/website/versioned_docs/version-5.x/layout-overview.md
+++ b/website/versioned_docs/version-5.x/layout-overview.md
@@ -47,7 +47,7 @@ You must use single-spa@>=5.4.0 in order for the layout engine to work. Addition
 
 ## Basic usage
 
-In your root html file, add a `<single-spa-router>` element to the body. It should contain `<route>` elements, `<application>` elements, and any other dom elements:
+In your root HTML file, add a `<single-spa-router>` element to the body. It should contain `<route>` elements, `<application>` elements, and any other dom elements:
 
 ```html
 <html>
@@ -72,7 +72,7 @@ In your root html file, add a `<single-spa-router>` element to the body. It shou
 </html>
 ```
 
-Then inside of your root-config's javascript code, add the following:
+Then inside of your root-config's JavaScript code, add the following:
 
 ```js
 import { registerApplication, start } from 'single-spa';

--- a/website/versioned_docs/version-5.x/microfrontends-concept.md
+++ b/website/versioned_docs/version-5.x/microfrontends-concept.md
@@ -10,23 +10,23 @@ Tutorial video: [Youtube](https://www.youtube.com/watch?v=3EUfbnHi6Wg&list=PLLUD
 
 A microfrontend is a microservice that exists within a browser.
 
-Microfrontends are sections of your UI, often consisting of dozens of components, that use frameworks like React, Vue, and Angular to render their components. Each microfrontend can be managed by a different team, and may choose its own framework. It is practical and suggested to use just one framework for all your microfrontends, although you may add additional framework when migrating or when experimenting.
+Microfrontends are sections of your UI, often consisting of dozens of components, that use frameworks like React, Vue, and Angular to render their components. Each microfrontend can be managed by a different team and may be implemented using its own framework. It is practical and suggested to use just one framework for all your microfrontends, although you may add additional frameworks when migrating or when experimenting.
 
-Each microfrontend has its own git repository, its own package.json, and its own build tool configuration. As a result, each microfrontend has **an independent build process** and **an independent deploy / CI**. This generally means that each repo has fast build times.
+Each microfrontend has its own git repository, its own `package.json` file, and its own build tool configuration. As a result, each microfrontend has **an independent build process** and **an independent deploy / CI**. This generally means that each repo has fast build times.
 
-## Comparison to microservices
+## Comparison to Microservices
 
 Microservices are backend services that run in their own operating system process, control their own databases, and communicate with each other over the network.
 
-Compare that to microfrontends that all exist within a single browser tab: all browser javascript within a tab exists in a single operating system process (and even thread!). Browser javascript generally does not directly access databases, and communication within a browser tab happens in-memory instead of over the network.
+Compare that to microfrontends that all exist within a single browser tab: all browser JavaScript within a tab exists in a single operating system process (and even thread!). Browser JavaScript generally does not directly access databases, and communication within a browser tab happens in-memory instead of over the network.
 
 So what do they have in common???
 
 Independent builds and deployments. Think of the DOM as the shared resource that your microfrontends are owning. One microfrontend's DOM should not be touched by another microfrontend, similar to how one backend microservice's database should not be touched by any microservice except the one that owns/controls it.
 
-## Concrete technical definition
+## Concrete Technical Definition
 
-In the context of single-spa, a microfrontend is often an in-browser javascript module. You can read more about this [in the recommended setup](/docs/recommended-setup#in-browser-versus-build-time-modules).
+In the context of single-spa, a microfrontend is often an in-browser JavaScript module. You can read more about this [in the recommended setup](/docs/recommended-setup#in-browser-versus-build-time-modules).
 
 ## Types of Microfrontends
 
@@ -34,7 +34,7 @@ In the context of single-spa, there are three kinds of microfrontends:
 
 1. [single-spa applications](/docs/building-applications): Microfrontends that render components for a set of specific routes.
 2. [single-spa parcels](/docs/parcels-overview): Microfrontends that render components without controlling routes.
-3. [utility modules](/docs/recommended-setup#utility-modules-styleguide-api-etc): Microfrontends that export shared javascript logic, without rendering components.
+3. [utility modules](/docs/recommended-setup#utility-modules-styleguide-api-etc): Microfrontends that export shared JavaScript logic, without rendering components.
 
 A web app may include one or more types of microfrontends. See [an in-depth comparison](/docs/module-types), and our recommendations for [choosing between microfrontend types](/docs/recommended-setup#applications-versus-parcels-versus-utility-modules).
 

--- a/website/versioned_docs/version-5.x/migrating-existing-spas.md
+++ b/website/versioned_docs/version-5.x/migrating-existing-spas.md
@@ -9,13 +9,13 @@ need to do three things:
 
 1. Create a [single spa config](./configuration)
 1. [Convert your SPA or SPAs to be registered applications](#converting-spas-into-registered-applications)
-1. Adjust your html file so that your single spa config is the new boss in town.
+1. Adjust your HTML file so that your single spa config is the new boss in town.
    See [docs](configuration#indexhtml-file).
 
 ## Converting SPAs into registered applications
 Your existing SPAs, whether they be Angular, React, or something else, probably are
 not used to unmounting themselves from the DOM. Also, they probably have had the luxury
-of controlling the entire html page themselves, instead of being purely javascript applications
+of controlling the entire HTML page themselves, instead of being purely JavaScript applications
 that don't have sole control over `<script>` tags and `<link>` tags. So in order to convert them
 into single-spa registered applications, they will need to overcome those obstacles while implementing
 lifecycle functions.
@@ -33,5 +33,5 @@ Since existing SPAs are used to having an index.html file for their css, fonts,
 third party script-tags, etc., it's likely that you'll have to do some work
 to make sure all of those keep on working when your SPA becomes an html-less [
 application](building-applications.md). It is best to try to put all that
-you can into the javascript bundle, but your escape hatch is to put the things
+you can into the JavaScript bundle, but your escape hatch is to put the things
 you need into your [single spa config](configuration).

--- a/website/versioned_docs/version-5.x/module-types.md
+++ b/website/versioned_docs/version-5.x/module-types.md
@@ -18,7 +18,7 @@ Here is how each single-spa microfrontend works conceptually. This information s
 | lifecycles           | single-spa managed lifecycles     | custom managed lifecycles            | no lifecycles                        |
 | When to use          | Core building block               | only needed with multiple frameworks | useful to share common logic         |
 
-Each single-spa microfrontend is an in-browser javascript module ([explanation](./recommended-setup#in-browser-versus-build-time-modules.md)).
+Each single-spa microfrontend is an in-browser JavaScript module ([explanation](./recommended-setup#in-browser-versus-build-time-modules.md)).
 
 ## Applications
 
@@ -45,7 +45,7 @@ in a way that will make it work inside `application2` despite the different fram
 Think of parcels as a single-spa specific implementation of webcomponents.
 
 ## Utility modules share common logic
-Utility modules are a great place to share common logic. Instead of each application creating their own implementation of common logic, you can use a plain javascript object (single-spa utility) to share that logic.
+Utility modules are a great place to share common logic. Instead of each application creating their own implementation of common logic, you can use a plain JavaScript object (single-spa utility) to share that logic.
 For example: Authorization. How does each application know which user is logged in? You could have each application ask the server or read a JWT but that creates duplicate work in each application.
 Using Utility modules you can implement logic around who is logged in one module (with all the necessary methods exported on the module) and each single-spa application can use the logic by importing the methods from the utilty module.
 This approach also works well for data [fetching](./recommended-setup#api-data.md).

--- a/website/versioned_docs/version-5.x/parcels-api.md
+++ b/website/versioned_docs/version-5.x/parcels-api.md
@@ -13,7 +13,7 @@ They both return a [parcel object](parcels-api.md#parcel-object). The parcel obj
 
 ### Parcel Props
 
-When mounting a parcel the second argument is props, a javascript object of properties to be passed to the parcel. This object must have a domElement prop, which is the dom node that the parcel will mount into.
+When mounting a parcel the second argument is props, a JavaScript object of properties to be passed to the parcel. This object must have a domElement prop, which is the dom node that the parcel will mount into.
 
 ```js
 const parcelProps = {

--- a/website/versioned_docs/version-5.x/recommended-setup.md
+++ b/website/versioned_docs/version-5.x/recommended-setup.md
@@ -24,7 +24,7 @@ We recommend a setup that uses in-browser ES modules + import maps (or SystemJS 
 
 Tutorial video: [Youtube](https://www.youtube.com/watch?v=Jxqiu6pdMSU&list=PLLUD8RtHvsAOhtHnyGx57EYXoaNsxGrTU&index=2) / [Bilibili](https://www.bilibili.com/video/av83498486/)
 
-An in-browser javascript module is when imports and exports are not compiled away by your build tool, but instead are
+An in-browser JavaScript module is when imports and exports are not compiled away by your build tool, but instead are
 resolved within the browser. This is different from build-time modules, which are supplied by your node_modules and
 compiled away before they touch the browser.
 
@@ -74,7 +74,7 @@ The single-spa core team recommends choosing either import maps or module federa
 
 Tutorial video: [Youtube](https://www.youtube.com/watch?v=AmdKF2UhFzw&list=PLLUD8RtHvsAOhtHnyGx57EYXoaNsxGrTU&index=7) / [Bilibili](https://www.bilibili.com/video/av83620028/)
 
-SystemJS provides polyfill-like behavior for import maps and in-browser modules. It is not a true polyfill of import maps, due to limitations of the javascript language in polyfilling the resolution of bare import specifiers to URLs.
+SystemJS provides polyfill-like behavior for import maps and in-browser modules. It is not a true polyfill of import maps, due to limitations of the JavaScript language in polyfilling the resolution of bare import specifiers to URLs.
 
 Since SystemJS is only polyfill-like, you'll need to compile your applications into [System.register format](https://github.com/systemjs/systemjs/blob/master/docs/system-register.md) instead of to ESM format. This allows for in-browser modules to be fully emulated in environments that don't support modules or import maps.
 
@@ -88,7 +88,7 @@ An alternative to SystemJS that provides polyfill behavior for import maps is [e
 
 Tutorial video: [Youtube](https://www.youtube.com/watch?v=-LkvBMpCK-A&list=PLLUD8RtHvsAOhtHnyGx57EYXoaNsxGrTU&index=8) / [Bilibili](https://www.bilibili.com/video/av83620658/)
 
-Lazy loading is when you only download javascript code that the user needs for the current page, instead of all javascript upfront. It is a technique for improving the performance of your application by decreasing the time-to-meaningful-render when you initially load the page. If you use [single-spa loading functions](/docs/configuration#loading-function-or-application), you already have built-in lazy loading for your applications and parcels. Since an application is an "in-browser module," this means that you are only downloading the in-browser modules in your import map when you need them.
+Lazy loading is when you only download JavaScript code that the user needs for the current page, instead of all JavaScript up front. It is a technique for improving the performance of your application by decreasing the time-to-meaningful-render when you initially load the page. If you use [single-spa loading functions](/docs/configuration#loading-function-or-application), you already have built-in lazy loading for your applications and parcels. Since an application is an "in-browser module," this means that you are only downloading the in-browser modules in your import map when you need them.
 
 Often, the route-based lazy loading provided by single-spa loading functions is all that you need to ensure great performance. However, it is also possible to do lazy loading via "code splits" with your bundler (webpack or rollup). For documentation on webpack code splits, see [these docs](https://webpack.js.org/guides/code-splitting/#dynamic-imports). It is recommended to use dynamic import (`import()`) instead of multiple entry points for code splits in a single-spa application. For code splits to work properly, you'll need to [dynamically set your public path](https://webpack.js.org/guides/public-path/#on-the-fly). A tool exists to help you set your public path correctly for use with systemjs - https://github.com/joeldenning/systemjs-webpack-interop.
 
@@ -118,13 +118,13 @@ Additionally, you have the choice of running your single-spa root config locally
 
 Tutorial video: [Youtube](https://www.youtube.com/watch?v=I6COIg-2lyM&list=PLLUD8RtHvsAOhtHnyGx57EYXoaNsxGrTU&index=9) / [Bilibili](https://www.bilibili.com/video/av84104639/)
 
-It is highly encouraged to use a bundler such as webpack, rollup, parceljs, pikapack, etc. Webpack is an industry-standard for compiling many javascript source files into one or more production javascript bundles.
+It is highly encouraged to use a bundler such as webpack, rollup, parceljs, pikapack, etc. Webpack is an industry-standard for compiling many JavaScript source files into one or more production JavaScript bundles.
 
 Below are some tips for configuring your bundler to be consumable by SystemJS and single-spa. Note that if you're using [create-single-spa](/docs/create-single-spa) that these are all set up for you. We leave these instructions here not to overwhelm you with webpack configuration hell, but rather to help you if you choose not to use create-single-spa.
 
 1. Set the output target to `system`. In webpack, this is done via [`output.libraryTarget`](https://webpack.js.org/configuration/output/#outputlibrarytarget)
 2. Use a single [entry point](https://webpack.js.org/concepts/entry-points/#root), with [dynamic imports](https://webpack.js.org/guides/code-splitting/#dynamic-imports) for any code splitting that you'd like to accomplish. This best matches the "one bundled project = one in-browser module" paradigm encouraged by the single-spa core team.
-3. Do not use webpack's [`optimization`](https://webpack.js.org/configuration/optimization/#root) configuration options, as they make it harder to load the outputted javascript files as a single in-browser javascript module. Doing so does not make your bundle less optimized - dynamic imports are a viable strategy for accomplishing optimized bundles.
+3. Do not use webpack's [`optimization`](https://webpack.js.org/configuration/optimization/#root) configuration options, as they make it harder to load the outputted JavaScript files as a single in-browser JavaScript module. Doing so does not make your bundle less optimized - dynamic imports are a viable strategy for accomplishing optimized bundles.
 4. Follow [the systemjs docs for webpack](https://github.com/systemjs/systemjs#compatibility-with-webpack).
 5. Consider using [systemjs-webpack-interop](https://github.com/joeldenning/systemjs-webpack-interop) to create or verify your webpack config.
 6. Use [systemjs-webpack-interop](https://github.com/joeldenning/systemjs-webpack-interop) to [set your webpack public path "on the fly"](https://webpack.js.org/guides/public-path/#on-the-fly).
@@ -141,7 +141,7 @@ For a bit more information specific to webpack code splits, see [the code splits
 
 ## Utility modules (styleguide, API, etc)
 
-A "utility module" is an in-browser javascript module that is not a single-spa application or parcel. In other words, it's only purpose is to export functionality for other microfrontends to import.
+A "utility module" is an in-browser JavaScript module that is not a single-spa application or parcel. In other words, it's only purpose is to export functionality for other microfrontends to import.
 
 Common examples of utility modules include styleguides, authentication helpers, and API helpers. These modules do not need to be registered with single-spa, but are important for maintaining consistency between several single-spa applications and parcels.
 
@@ -186,7 +186,7 @@ To make utility modules work, you must ensure that your webpack externals and im
 
 ## Shared dependencies
 
-For performance, it is crucial that your web app loads large javascript libraries only once. Your framework of choice (React, Vue, Angular, etc) should only be loaded on the page a single time.
+For performance, it is crucial that your web app loads large JavaScript libraries only once. Your framework of choice (React, Vue, Angular, etc) should only be loaded on the page a single time.
 
 It is not advisable to make everything a shared dependency, because shared dependencies must be upgraded at once for every microfrontend that uses them. For small libraries, it is likely acceptable to duplicate them in each microfrontend that uses them. For example, react-router is likely small enough to duplicate, which is nice when you want to upgrade your routing one microfrontend at a time. However, for large libraries like react, momentjs, rxjs, etc, you may consider making them shared dependencies.
 
@@ -230,7 +230,7 @@ Microfrontends are built and deployed completely independently. This means that 
 
 There are two steps to deploying a microfrontend.
 
-1. Uploading production javascript bundles to a web server / CDN. It is encouraged to use a CDN such as AWS S3 + Cloudfront, Google Cloud Storage, Microsoft Azure Storage, Digital Ocean Spaces, etc because of their superior availability, caching, and performance due to edge locations. The javascript files that you upload are completely static. It is encouraged to always write new files to the CDN instead of overwriting files.
+1. Uploading production JavaScript bundles to a web server / CDN. It is encouraged to use a CDN such as AWS S3 + Cloudfront, Google Cloud Storage, Microsoft Azure Storage, Digital Ocean Spaces, etc because of their superior availability, caching, and performance due to edge locations. The JavaScript files that you upload are completely static. It is encouraged to always write new files to the CDN instead of overwriting files.
 2. Updating your import map to point to the newly deployed file.
 
 The implementation of Step 1 is dependent on the infrastructure you're using for your CDN. The AWS CLI ([`aws s3 sync`](https://docs.aws.amazon.com/cli/latest/reference/s3/)), Google gsutil ([`gsutil cp`](https://github.com/single-spa/import-map-deployer/blob/master/examples/ci-for-javascript-repo/gitlab-gcp-storage/.gitlab-ci.yml)), etc are easy ways of accomplishing this.
@@ -269,7 +269,7 @@ There are three things that microfrontends might need to share / communicate:
 
 Example - [exporting a shared component](https://github.com/vue-microfrontends/styleguide/blob/af3eaa70bec7daa74635eb3ec76140fb647b0b14/src/vue-mf-styleguide.js#L5) and [importing a shared component](https://github.com/vue-microfrontends/rate-dogs/blob/fe3196234b9cbd6d627199b03a96e7b5f0285c4b/src/components/rate-dogs.vue#L25).
 
-You can import and export functions, components, logic, and environment variables between your microfrontends that are in different git repos and javascript bundles:
+You can import and export functions, components, logic, and environment variables between your microfrontends that are in different git repos and JavaScript bundles:
 
 ```js
 // Inside of a utility module called @org-name/auth
@@ -289,7 +289,7 @@ const showLinkToInvoiceFeature = userHasAccess('invoicing');
 
 Example - [exporting a `fetchWithCache` function](https://github.com/react-microfrontends/api/blob/c3c336129e920bbc6137f04cce24b718105efed1/src/react-mf-api.js#L3) and [importing the function](https://github.com/react-microfrontends/people/blob/ad18de9b96b52e6975244e6662becfe13e41a2db/src/utils/api.js#L1).
 
-API data often does not need to be shared between microfrontends, since each single-spa application controls different routes and different routes often have different data. However, occasionally you do need to share API data between microfrontends. An in-memory javascript cache of API objects is a solution used by several companies to solve this. For React users, this is similar to Data Fetching with Suspense, where the fetching logic for routes is split out from the component code that uses the data.
+API data often does not need to be shared between microfrontends, since each single-spa application controls different routes and different routes often have different data. However, occasionally you do need to share API data between microfrontends. An in-memory JavaScript cache of API objects is a solution used by several companies to solve this. For React users, this is similar to Data Fetching with Suspense, where the fetching logic for routes is split out from the component code that uses the data.
 
 ```js
 // Inside of your api utility module, you can lazily fetch data either when another microfrontend calls your exported

--- a/website/versioned_docs/version-5.x/separating-applications.md
+++ b/website/versioned_docs/version-5.x/separating-applications.md
@@ -4,7 +4,7 @@ title: Splitting up applications
 sidebar_label: Splitting applications
 ---
 
-In a large, microserviced system, your root single-spa configuration and each of the applications should probably have its own git repository. How to do that in a javascript project isn't necessarily clear, so some options are listed below.
+In a large, microserviced system, your root single-spa configuration and each of the applications should probably have its own git repository. How to do that in a JavaScript project isn't necessarily clear, so some options are listed below.
 
 Since single-spa is a framework that helps with organizational scaling, it is important to figure out how to split out and separate applications from each other so that developers and teams can work on the applications without interfering one another.
 
@@ -12,7 +12,7 @@ Most interpretations of microservice architecture encourage separate code reposi
 
 #### Option 1: One code repo, one build
 
-The simplest approach for using single-spa is to have one code repository with everything in it. Typically, you would have a single package.json with a single webpack config that produces a bundle that can be included in an html file with a `<script>` tag.
+The simplest approach for using single-spa is to have one code repository with everything in it. Typically, you would have a single package.json with a single webpack config that produces a bundle that can be included in an HTML file with a `<script>` tag.
 
 Advantages:
 
@@ -46,12 +46,12 @@ Disadvantages:
 
 Create a root application which can allow single-spa applications to deploy themselves separately. To do so,
 create a manifest file that the single-spa applications update during their deployment process, which controls
-which versions of the single-spa applications are "live". Then change which javascript file is loaded based on the manifest.
+which versions of the single-spa applications are "live". Then change which JavaScript file is loaded based on the manifest.
 
-Changing which javascript file is loaded for each child application can be done in many ways.
+Changing which JavaScript file is loaded for each child application can be done in many ways.
 
 1. Web server: have your webserver create a dynamic script tag for the "live" version of each single-spa application.
-2. Use a [module loader](https://www.jvandemo.com/a-10-minute-primer-to-javascript-modules-module-formats-module-loaders-and-module-bundlers/) such as [SystemJS](https://github.com/systemjs/systemjs) that can download and execute javascript code in the browser from dynamic urls.
+2. Use a [module loader](https://www.jvandemo.com/a-10-minute-primer-to-javascript-modules-module-formats-module-loaders-and-module-bundlers/) such as [SystemJS](https://github.com/systemjs/systemjs) that can download and execute JavaScript code in the browser from dynamic urls.
 
 #### Comparison
 

--- a/website/versioned_docs/version-5.x/single-spa-config.md
+++ b/website/versioned_docs/version-5.x/single-spa-config.md
@@ -7,7 +7,7 @@ sidebar_label: single-spa config
 The single spa root config consists of the following:
 
 1. The root HTML file that is shared by all single-spa applications.
-2. the javascript that calls [`singleSpa.registerApplication()`](/docs/api.html#registerapplication).
+2. The JavaScript that calls [`singleSpa.registerApplication()`](/docs/api.html#registerapplication).
 
 Your root config exists only to start up the single-spa applications.
 


### PR DESCRIPTION
Another petty update here. 😄 

I've corrected the casing for `html` to be `HTML` and `javascript` to be `JavaScript`.

I made sure to only change the instances in the docs that made sense and didn't touch things like `index.html` or `type="text/javascript"` where it makes sense to use all lowercase.