### PR TITLE
Fixing build errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,3 +42,8 @@ workflows:
             branches:
               ignore:
                 - gh-pages
+      - deploy-website:
+          filters:
+            branches:
+              ignore:
+                - gh-pages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,5 +45,5 @@ workflows:
       - deploy-website:
           filters:
             branches:
-              ignore:
-                - gh-pages
+              only:
+                - master

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -18,3 +18,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+static/.circleci

--- a/website/package.json
+++ b/website/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "start": "docusaurus start",
     "build": "docusaurus build",
-    "copycircle": "copyfiles -u 1 '../.circleci/**/*.*' build",
+    "copycircle": "copyfiles -u 1 '../.circleci/**/*.*' static",
     "swizzle": "docusaurus swizzle",
     "deploy": "yarn copycircle && docusaurus deploy",
     "eslint:check": "eslint src --ext .js,.jsx,.ts,.tsx --max-warnings 1",


### PR DESCRIPTION
Example: https://app.circleci.com/pipelines/github/single-spa/single-spa.js.org/247/workflows/83633637-7f02-4e99-aa08-f4b9cb1f967b. The reason is that `docusaurus deploy` is deleting the copied circle ci configuration file.