### PR TITLE
Fixes grammar issues in the MFE and Root Config pages

### DIFF
--- a/website/versioned_docs/version-4.x/single-spa-config.md
+++ b/website/versioned_docs/version-4.x/single-spa-config.md
@@ -1,16 +1,17 @@
 ---
 id: configuration
-title: Using single-spa-config
-sidebar_label: single-spa config
+title: Configuring single-spa
+sidebar_label: Configuring single-spa
 ---
 
-The single spa root config consists of the following:
+The single-spa root config consists of the following:
+
 1. The root HTML file that is shared by all single-spa applications.
 2. The JavaScript that calls [`singleSpa.registerApplication()`](/docs/api.html#registerapplication).
 
 Your root config exists only to start up the single-spa applications.
 
-## Index.html file
+## index.html file
 See [this example root config](http://single-spa-playground.org/playground/html-file) for what a root HTML file looks like.
 Notice how it does not have any divs or buttons, but just calls `registerApplication()`.
 
@@ -20,9 +21,9 @@ it allows you to [independently deploy](/docs/separating-applications.html) your
 ## Registering applications
 
 You must register [applications](building-applications.md) with single-spa so it knows how and when to
-initiate, load, mount, and unmount. Registration most commonly occurs inside of the single spa config, but
-does not have to. Note that if an application is registered from within another application, that no hierarchy
-will be maintained between the applications. Instead, the applications will be siblings and will be mounted
+initiate, load, mount, and unmount each application. Registration most commonly occurs inside of the single-spa config but
+does not have to. Note that if an application is registered from within another application, no hierarchy will be
+maintained between the applications. Instead, the applications will be siblings and will be mounted
 and unmounted according to their own activity functions.
 
 In order to register an application, call the `registerApplication(name, howToLoad, activityFunction)` api. Example:

--- a/website/versioned_docs/version-5.x/microfrontends-concept.md
+++ b/website/versioned_docs/version-5.x/microfrontends-concept.md
@@ -34,9 +34,9 @@ In the context of single-spa, there are three kinds of microfrontends:
 
 1. [single-spa applications](/docs/building-applications): Microfrontends that render components for a set of specific routes.
 2. [single-spa parcels](/docs/parcels-overview): Microfrontends that render components without controlling routes.
-3. [utility modules](/docs/recommended-setup#utility-modules-styleguide-api-etc): Microfrontends that export shared JavaScript logic, without rendering components.
+3. [utility modules](/docs/recommended-setup#utility-modules-styleguide-api-etc): Microfrontends that export shared JavaScript logic without rendering components.
 
-A web app may include one or more types of microfrontends. See [an in-depth comparison](/docs/module-types), and our recommendations for [choosing between microfrontend types](/docs/recommended-setup#applications-versus-parcels-versus-utility-modules).
+A web app may include one or more types of microfrontends. See [an in-depth comparison](/docs/module-types) and our recommendations for [choosing between microfrontend types](/docs/recommended-setup#applications-versus-parcels-versus-utility-modules).
 
 ## Communication between Microfrontends
 
@@ -44,8 +44,8 @@ A web app may include one or more types of microfrontends. See [an in-depth comp
 
 ## Relationship to single-spa
 
-single-spa is a small, 5kb (gzipped) npm package that orchestrates the mounting and unmounting of your microfrontends. It knows when to mount the applications based on [activity functions](/docs/api/#registerapplication), and can do so in a framework agnostic way with the help of small [adapter libraries](/docs/ecosystem).
+single-spa is a small, 5kb (gzipped) npm package that orchestrates the mounting and unmounting of your microfrontends. It knows when to mount the applications based on [activity functions](/docs/api/#registerapplication) and can do so in a framework agnostic way with the help of small [adapter libraries](/docs/ecosystem).
 
 ## Performance
 
-Microfrontends often are more performant than the monoliths from which they originate. This is due to built-in lazy loading (via [loading functions](/docs/api/#registerapplication)) and other performance-related best practices. Your monolith likely has "skeletons in its closet" - microfrontends gives you a migration path that will expose and resolve the problems caused by those skeletons. One important performance consideration is to share a single instance of large libraries (such as React, Vue, or Angular), which is highly encouraged. To do so, see our [recommended setup](/docs/recommended-setup#shared-dependencies).
+Microfrontends are often more performant than the monoliths from which they originate. This is due to built-in lazy loading (via [loading functions](/docs/api/#registerapplication)) and other performance-related best practices. Your monolith likely has "skeletons in its closet" - microfrontends gives you a migration path that will expose and resolve the problems caused by those skeletons. One important performance consideration is to share a single instance of large libraries (such as React, Vue, or Angular), which is highly encouraged. To do so, see our [recommended setup](/docs/recommended-setup#shared-dependencies).

--- a/website/versioned_docs/version-5.x/module-types.md
+++ b/website/versioned_docs/version-5.x/module-types.md
@@ -1,51 +1,53 @@
 ---
 id: module-types
-title: single-spa microfrontend types
+title: single-spa Microfrontend Types
 sidebar_label: Microfrontend Types
 ---
 
-# Concept: single-spa microfrontend types
+# Concept: single-spa Microfrontend Types
 
 Single-spa has [different categories](./microfrontends-concept#types-of-microfrontends.md) of microfrontends. It is up to you where and how you use each of them. However, the single-spa core team has [recommendations](./recommended-setup/#applications-versus-parcels-versus-utility-modules.md).
 
 Here is how each single-spa microfrontend works conceptually. This information should help you understand our [recommendations](./recommended-setup/#applications-versus-parcels-versus-utility-modules.md).
 
-| Topic                | application                       | parcel                               | utility                              |
+| Topic                | Application                       | Parcel                               | Utility                              |
 | -------------------- | --------------------------------- | ------------------------------------ | ------------------------------------ |
-| routing              | has multiple routes               | no routes                            | no routes                            |
-| API                  | declarative API                   | imperative API                       | no single-spa api                    |
-| renders UI           | renders UI                        | renders UI                           | doesn't directly render UI           |
-| lifecycles           | single-spa managed lifecycles     | custom managed lifecycles            | no lifecycles                        |
-| When to use          | Core building block               | only needed with multiple frameworks | useful to share common logic         |
+| Routing              | has multiple routes               | has no routes                        | has no routes                        |
+| API                  | declarative API                   | imperative API                       | no single-spa API                    |
+| Renders UI           | renders UI                        | renders UI                           | doesn't directly render UI           |
+| Lifecycles           | single-spa managed lifecycles     | custom managed lifecycles            | no lifecycles                        |
+| When to use          | core building block               | only needed with multiple frameworks | useful to share common logic         |
 
 Each single-spa microfrontend is an in-browser JavaScript module ([explanation](./recommended-setup#in-browser-versus-build-time-modules.md)).
 
 ## Applications
 
 ### Applications are declarative
-Applications use a declarative api called `registerApplication`. Your single-spa config (also sometimes called root config) defines applications ahead of time, defines the condition at which they are active, but doesn't mount the application directly.
+Applications use a declarative API called `registerApplication`. Your single-spa config (also sometimes called the root config) defines applications ahead of time and defines the conditions for when each application is active, but it doesn't mount the applications directly.
 
 ### Applications have managed lifecycles
 single-spa manages registered applications and is in charge of all of their lifecycles. This prevents you from writing a bunch of logic about when applications should mount and unmount; single-spa takes care of that for you.
-All single spa needs to make this work automatically is for an activity function that describes when your application should be active.
+All that single-spa needs to make this work automatically is an activity function that describes when your application should be active.
 
 ## Parcels
 
 ### Parcels are imperative
-Parcels exist in many ways as an escape hatch from the normal declarative flow. They exist primarily to allow you to reuse UI across applications when those applications are written in multiple frameworks.
+Parcels exist in many ways as an escape hatch from the normal declarative flow. They exist primarily to allow you to reuse pieces of UI across applications when those applications are written in multiple frameworks.
 
-### You manage the lifecycles of Parcels
-When you call `mountParcel` or `mountRootParcel` [(see api)](./parcels-api.md) the parcel is mounted immediately and returns the parcel object. You need to call the `unmount` method on the parcel manually when the component that calls `mountParcel` unmounts.
+### You manage the lifecycles of parcels
+When you call `mountParcel` or `mountRootParcel` [(see API)](./parcels-api.md) the parcel is mounted immediately and returns the parcel object. You need to call the `unmount` method on the parcel manually when the component that calls `mountParcel` unmounts.
 
-### Parcels are best suited for sharing UI between frameworks
+### Parcels are best suited for sharing pieces of UI between frameworks
 Creating a parcel is as easy as using the [single-spa helpers](./ecosystem#help-for-frameworks.md) for that framework on a specific component/UI. This returns an object (`parcelConfig`) that single-spa can use to create and mount a parcel.
 Because single-spa can mount a parcel anywhere, this gives you a way to share UI/components across frameworks. It should not be used if the shared UI is being used in another application of the same framework.
-For example: `applicationOne` is written in Vue and contains all the UI/Logic to create a user. `application2` is written in React and needs to create a user. Using a single-spa parcel allows you to wrap your `app1` Vue component
-in a way that will make it work inside `application2` despite the different frameworks. Even better if `application2` is unmounted by single-spa (per the activity function returning false)
+For example: `application1` is written in Vue and contains all the UI and logic to create a user. `application2` is written in React and needs to create a user. Using a single-spa parcel allows you to wrap your `application1` Vue component
+in a way that will make it work inside `application2` despite the different frameworks.
 Think of parcels as a single-spa specific implementation of webcomponents.
 
-## Utility modules share common logic
+## Utilities
+
+### Utility modules share common logic
 Utility modules are a great place to share common logic. Instead of each application creating their own implementation of common logic, you can use a plain JavaScript object (single-spa utility) to share that logic.
 For example: Authorization. How does each application know which user is logged in? You could have each application ask the server or read a JWT but that creates duplicate work in each application.
-Using Utility modules you can implement logic around who is logged in one module (with all the necessary methods exported on the module) and each single-spa application can use the logic by importing the methods from the utilty module.
+Using utility modules, you can implement logic around who is logged in all in one module (with all the necessary methods exported on the module) and each single-spa application can use the logic by importing the methods from the utilty module.
 This approach also works well for data [fetching](./recommended-setup#api-data.md).

--- a/website/versioned_docs/version-5.x/module-types.md
+++ b/website/versioned_docs/version-5.x/module-types.md
@@ -49,5 +49,5 @@ Think of parcels as a single-spa specific implementation of webcomponents.
 ### Utility modules share common logic
 Utility modules are a great place to share common logic. Instead of each application creating their own implementation of common logic, you can use a plain JavaScript object (single-spa utility) to share that logic.
 For example: Authorization. How does each application know which user is logged in? You could have each application ask the server or read a JWT but that creates duplicate work in each application.
-Using utility modules, you can implement logic around who is logged in all in one module (with all the necessary methods exported on the module) and each single-spa application can use the logic by importing the methods from the utilty module.
+Using the utility module pattern would allow you to create one module that implements the authorization logic. This module would export any needed methods, and then your other single-spa applications could use those authorization methods by importing them.
 This approach also works well for data [fetching](./recommended-setup#api-data.md).

--- a/website/versioned_docs/version-5.x/single-spa-config.md
+++ b/website/versioned_docs/version-5.x/single-spa-config.md
@@ -1,17 +1,17 @@
 ---
 id: configuration
-title: Using single-spa-config
-sidebar_label: single-spa config
+title: Configuring single-spa
+sidebar_label: Configuring single-spa
 ---
 
-The single spa root config consists of the following:
+The single-spa root config consists of the following:
 
 1. The root HTML file that is shared by all single-spa applications.
 2. The JavaScript that calls [`singleSpa.registerApplication()`](/docs/api.html#registerapplication).
 
 Your root config exists only to start up the single-spa applications.
 
-## Index.html file
+## index.html file
 See [this example root config](http://single-spa-playground.org/playground/html-file) for what a root HTML file looks like.
 Notice how it does not have any divs or buttons, but just calls `registerApplication()`.
 
@@ -21,9 +21,9 @@ it allows you to [independently deploy](/docs/separating-applications.html) your
 ## Registering applications
 
 You must register [applications](building-applications.md) with single-spa so it knows how and when to
-initiate, load, mount, and unmount. Registration most commonly occurs inside of the single spa config, but
-does not have to. Note that if an application is registered from within another application, that no hierarchy
-will be maintained between the applications. Instead, the applications will be siblings and will be mounted
+initiate, load, mount, and unmount each application. Registration most commonly occurs inside of the single-spa config but
+does not have to. Note that if an application is registered from within another application, no hierarchy will be
+maintained between the applications. Instead, the applications will be siblings and will be mounted
 and unmounted according to their own activity functions.
 
 In order to register an application, call the `registerApplication` function. Example:
@@ -37,7 +37,7 @@ registerApplication(
   'app2',
   () => import('src/app2/main.js'),
   (location) => location.pathname.startsWith('/app2'),
-  {some: 'value'}
+  { some: 'value' }
 );
 
 // Config with more expressive API


### PR DESCRIPTION
I went through the following pages and corrected minor typos and grammar issues.

- https://single-spa.js.org/docs/microfrontends-concept
- https://single-spa.js.org/docs/module-types
- https://single-spa.js.org/docs/configuration