### PR TITLE
fix: remove .md extension in anchor tags

### DIFF
--- a/website/versioned_docs/version-5.x/module-types.md
+++ b/website/versioned_docs/version-5.x/module-types.md
@@ -6,9 +6,9 @@ sidebar_label: Microfrontend Types
 
 # Concept: single-spa Microfrontend Types
 
-Single-spa has [different categories](./microfrontends-concept#types-of-microfrontends.md) of microfrontends. It is up to you where and how you use each of them. However, the single-spa core team has [recommendations](./recommended-setup/#applications-versus-parcels-versus-utility-modules.md).
+Single-spa has [different categories](./microfrontends-concept#types-of-microfrontends) of microfrontends. It is up to you where and how you use each of them. However, the single-spa core team has [recommendations](./recommended-setup/#applications-versus-parcels-versus-utility-modules).
 
-Here is how each single-spa microfrontend works conceptually. This information should help you understand our [recommendations](./recommended-setup/#applications-versus-parcels-versus-utility-modules.md).
+Here is how each single-spa microfrontend works conceptually. This information should help you understand our [recommendations](./recommended-setup/#applications-versus-parcels-versus-utility-modules).
 
 | Topic                | Application                       | Parcel                               | Utility                              |
 | -------------------- | --------------------------------- | ------------------------------------ | ------------------------------------ |
@@ -18,7 +18,7 @@ Here is how each single-spa microfrontend works conceptually. This information s
 | Lifecycles           | single-spa managed lifecycles     | custom managed lifecycles            | no lifecycles                        |
 | When to use          | core building block               | only needed with multiple frameworks | useful to share common logic         |
 
-Each single-spa microfrontend is an in-browser JavaScript module ([explanation](./recommended-setup#in-browser-versus-build-time-modules.md)).
+Each single-spa microfrontend is an in-browser JavaScript module ([explanation](./recommended-setup#in-browser-versus-build-time-modules)).
 
 ## Applications
 
@@ -38,7 +38,7 @@ Parcels exist in many ways as an escape hatch from the normal declarative flow. 
 When you call `mountParcel` or `mountRootParcel` [(see API)](./parcels-api.md) the parcel is mounted immediately and returns the parcel object. You need to call the `unmount` method on the parcel manually when the component that calls `mountParcel` unmounts.
 
 ### Parcels are best suited for sharing pieces of UI between frameworks
-Creating a parcel is as easy as using the [single-spa helpers](./ecosystem#help-for-frameworks.md) for that framework on a specific component/UI. This returns an object (`parcelConfig`) that single-spa can use to create and mount a parcel.
+Creating a parcel is as easy as using the [single-spa helpers](./ecosystem#help-for-frameworks) for that framework on a specific component/UI. This returns an object (`parcelConfig`) that single-spa can use to create and mount a parcel.
 Because single-spa can mount a parcel anywhere, this gives you a way to share UI/components across frameworks. It should not be used if the shared UI is being used in another application of the same framework.
 For example: `application1` is written in Vue and contains all the UI and logic to create a user. `application2` is written in React and needs to create a user. Using a single-spa parcel allows you to wrap your `application1` Vue component
 in a way that will make it work inside `application2` despite the different frameworks.
@@ -50,4 +50,4 @@ Think of parcels as a single-spa specific implementation of webcomponents.
 Utility modules are a great place to share common logic. Instead of each application creating their own implementation of common logic, you can use a plain JavaScript object (single-spa utility) to share that logic.
 For example: Authorization. How does each application know which user is logged in? You could have each application ask the server or read a JWT but that creates duplicate work in each application.
 Using the utility module pattern would allow you to create one module that implements the authorization logic. This module would export any needed methods, and then your other single-spa applications could use those authorization methods by importing them.
-This approach also works well for data [fetching](./recommended-setup#api-data.md).
+This approach also works well for data [fetching](./recommended-setup#api-data).


### PR DESCRIPTION
Scrolling to anchor tags was not working due to having .md in the URL. By removing the file extension from the target link, scrolling works as expected. 

Keep in mind, that this only works in the production build and not in dev mode (https://github.com/facebook/docusaurus/issues/2399)