### PR TITLE
Fixing links

### DIFF
--- a/website/versioned_docs/version-5.x/api.md
+++ b/website/versioned_docs/version-5.x/api.md
@@ -441,7 +441,7 @@ Will create and mount a [single-spa parcel](parcels-overview.md).
 
 ## pathToActiveWhen
 
-The `pathToActiveWhen` function converts a string URL path into an [activity function](./configuration#activity-function). The string path may contain route parameters that single-spa will match any characters to. It assumes that the string provided is a **prefix**.
+The `pathToActiveWhen` function converts a string URL path into an [activity function](/docs/configuration/#activity-function). The string path may contain route parameters that single-spa will match any characters to. It assumes that the string provided is a **prefix**.
 
 This function is used by single-spa when a string is passed into `registerApplication` as the `activeWhen` argument.
 

--- a/website/versioned_docs/version-5.x/building-applications.md
+++ b/website/versioned_docs/version-5.x/building-applications.md
@@ -8,7 +8,7 @@ A single-spa registered application is everything that a normal SPA is, except t
 
 ## Creating a registered application
 
-To create a registered application, first [register the application with single-spa](./configuration/#registering-applications). Once registered, the registered application must correctly implement **all** of the following lifecycle functions inside of its main entry point.
+To create a registered application, first [register the application with single-spa](/docs/configuration//#registering-applications). Once registered, the registered application must correctly implement **all** of the following lifecycle functions inside of its main entry point.
 
 ## Registered application lifecycle
 

--- a/website/versioned_docs/version-5.x/building-applications.md
+++ b/website/versioned_docs/version-5.x/building-applications.md
@@ -8,7 +8,7 @@ A single-spa registered application is everything that a normal SPA is, except t
 
 ## Creating a registered application
 
-To create a registered application, first [register the application with single-spa](/docs/configuration//#registering-applications). Once registered, the registered application must correctly implement **all** of the following lifecycle functions inside of its main entry point.
+To create a registered application, first [register the application with single-spa](/docs/configuration/#registering-applications). Once registered, the registered application must correctly implement **all** of the following lifecycle functions inside of its main entry point.
 
 ## Registered application lifecycle
 

--- a/website/versioned_docs/version-5.x/contributing-overview.md
+++ b/website/versioned_docs/version-5.x/contributing-overview.md
@@ -35,7 +35,7 @@ Interested in making a contribution? Read on!
 Before we get started, here are a few things we expect from you (and that you should expect from others):
 
 * Be kind and thoughtful in your conversations around this project. We all come from different backgrounds and projects, which means we likely have different perspectives on "how open source is done." Try to listen to others rather than convince them that your way is correct.
-* Please read the single-spa [Contributor Code of Conduct](./CODE_OF_CONDUCT.md). By participating in this project, you agree to abide by its terms.
+* Please read the single-spa [Contributor Code of Conduct](/docs/code-of-conduct/). By participating in this project, you agree to abide by its terms.
 * If you open a pull request, please ensure that your contribution passes all tests. If there are test failures, you will need to address them before we can merge your contribution.
 * When adding content, please consider if it is widely valuable. Please don't add references or links to things you or your employer have created as others will do so if they appreciate it.
 

--- a/website/versioned_docs/version-5.x/ecosystem-angularjs.md
+++ b/website/versioned_docs/version-5.x/ecosystem-angularjs.md
@@ -101,7 +101,7 @@ All options are passed to single-spa-angularjs via the `opts` parameter when cal
 
 ## Custom Props
 
-[single-spa custom props](./building-applications.md#lifecycle-props) are made available as `$rootScope.singleSpaProps`.
+[single-spa custom props](/docs/building-applications/#lifecycle-props) are made available as `$rootScope.singleSpaProps`.
 
 ## Examples
 

--- a/website/versioned_docs/version-5.x/ecosystem-svelte.md
+++ b/website/versioned_docs/version-5.x/ecosystem-svelte.md
@@ -41,4 +41,4 @@ Svelte-specific options
 
 ## single-spa props
 
-All [single-spa props](./api.md#registerapplication) are passed to the svelte component as props. The props provided to `singleSpaSvelte({props: {...}})` are merged with the single-spa props.
+All [single-spa props](/docs/api/#registerapplication) are passed to the svelte component as props. The props provided to `singleSpaSvelte({props: {...}})` are merged with the single-spa props.

--- a/website/versioned_docs/version-5.x/ecosystem.md
+++ b/website/versioned_docs/version-5.x/ecosystem.md
@@ -11,18 +11,18 @@ There is a growing number of projects that help you bootstrap, mount,
 and unmount your applications that are written with popular frameworks. Feel free
 to contribute to this list with your own project:
 
-- [single-spa-react](./ecosystem-react.md)
-- [single-spa-vue](./ecosystem-vue.md)
-- [single-spa-angular](./ecosystem-angular.md)
-- [single-spa-angularjs](./ecosystem-angularjs.md)
-- [single-spa-cycle](./ecosystem-cycle.md)
-- [single-spa-ember](./ecosystem-ember.md)
-- [single-spa-inferno](./ecosystem-inferno.md)
-- [single-spa-preact](./ecosystem-preact.md)
-- [single-spa-svelte](./ecosystem-svelte.md)
-- [single-spa-riot](./ecosystem-riot.md)
-- [single-spa-backbone](./ecosystem-backbone.md)
-- [single-spa-dojo](./ecosystem-dojo.md)
+- [single-spa-react](/docs/ecosystem-react/)
+- [single-spa-vue](/docs/ecosystem-vue/)
+- [single-spa-angular](/docs/ecosystem-angular/)
+- [single-spa-angularjs](/docs/ecosystem-angularjs/)
+- [single-spa-cycle](/docs/ecosystem-cycle/)
+- [single-spa-ember](/docs/ecosystem-ember/)
+- [single-spa-inferno](/docs/ecosystem-inferno/)
+- [single-spa-preact](/docs/ecosystem-preact/)
+- [single-spa-svelte](/docs/ecosystem-svelte/)
+- [single-spa-riot](/docs/ecosystem-riot/)
+- [single-spa-backbone](/docs/ecosystem-backbone/)
+- [single-spa-dojo](/docs/ecosystem-dojo/)
 
 ## Other helpful libraries
 

--- a/website/versioned_docs/version-5.x/faq.md
+++ b/website/versioned_docs/version-5.x/faq.md
@@ -106,13 +106,13 @@ Some options on _how_ to update your import map include:
 
 Tutorial video: [Youtube](https://www.youtube.com/watch?v=W8oaySHuj3Y&list=PLLUD8RtHvsAOhtHnyGx57EYXoaNsxGrTU&index=10) / [Bilibili](https://www.bilibili.com/video/BV16Z4y1j72X/)
 
-If you are starting from scratch, it is preferred to use [create-single-spa](./create-single-spa.md) instead of create-react-app.
+If you are starting from scratch, it is preferred to use [create-single-spa](/docs/create-single-spa/) instead of create-react-app.
 
 Create React App (CRA) projects must be altered before use with single-spa. The reason is that CRA presumes that each project has its own HTML file, whereas in single-spa all microfrontends must share an HTML file.
 
 Here are your options:
 
-1. Remove `react-scripts` and then run [`create-single-spa`](./create-single-spa.md) on your project. This will merge create-single-spa's package.json with yours, and provide you with a default webpack config. Run `yarn start` and fix webpack configuration errors until it's working.
+1. Remove `react-scripts` and then run [`create-single-spa`](/docs/create-single-spa/) on your project. This will merge create-single-spa's package.json with yours, and provide you with a default webpack config. Run `yarn start` and fix webpack configuration errors until it's working.
 1. Use [react-app-rewired](https://github.com/timarney/react-app-rewired/blob/master/README.md) to modify the webpack config. See [this Gist](https://gist.github.com/joeldenning/79f2592086ad132fae8ee5aae054c0b6) that shows a basic config you can start with. The example config may not work in every case or solve every problem.
 1. [Eject](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#npm-run-eject) your CRA project's webpack config so you can modify it.
 

--- a/website/versioned_docs/version-5.x/getting-started-overview.md
+++ b/website/versioned_docs/version-5.x/getting-started-overview.md
@@ -37,7 +37,7 @@ single-spa apps consist of the following:
 
 ## The Recommended Setup
 
-The single-spa core team has put together documentation, tools, and videos showing the currently encouraged best practices with single-spa. Check out [these docs](./recommended-setup.md) for more information.
+The single-spa core team has put together documentation, tools, and videos showing the currently encouraged best practices with single-spa. Check out [these docs](/docs/recommended-setup/) for more information.
 
 ## How hard will it be to use single-spa?
 
@@ -70,7 +70,7 @@ You can help improve the single-spa website by sending pull requests to the [`si
 
 ## Simple Usage
 
-For a full example, check out [this simple webpack example](https://github.com/joeldenning/simple-single-spa-webpack-example) or [these examples](./examples.md).
+For a full example, check out [this simple webpack example](https://github.com/joeldenning/simple-single-spa-webpack-example) or [these examples](/docs/examples/).
 
 To create a single-spa application, you will need to do three things:
 
@@ -157,7 +157,7 @@ single-spa has adopted a Code of Conduct that we expect project participants to 
 
 ### [Contributing Guide](contributing-overview.md)
 
-Read our [contributing guide](./contributing-overview.md) to learn about our development process, how to propose bugfixes and improvements, and how to build and test your changes to single-spa.
+Read our [contributing guide](/docs/contributing-overview/) to learn about our development process, how to propose bugfixes and improvements, and how to build and test your changes to single-spa.
 
 ## Who's Using This?
 

--- a/website/versioned_docs/version-5.x/layout-api.md
+++ b/website/versioned_docs/version-5.x/layout-api.md
@@ -8,7 +8,7 @@ The single-spa-layout library exposes several javascript functions as a public A
 
 ## constructRoutes
 
-The `constructRoutes` API transforms your [Layout Definition](./layout-definition.md) into an opaque "resolved routes" object. We call it "opaque" because the shape of the object is irrelevant, as you will only use it when calling other APIs within single-spa-layout.
+The `constructRoutes` API transforms your [Layout Definition](/docs/layout-definition/) into an opaque "resolved routes" object. We call it "opaque" because the shape of the object is irrelevant, as you will only use it when calling other APIs within single-spa-layout.
 
 ```js
 import { constructRoutes } from 'single-spa-layout';
@@ -31,8 +31,8 @@ const resolvedRoutes = constructRoutes(htmlTemplate, layoutData)
 
 **Arguments**
 
-- `routesConfig` (required): Routes config is a [JSON Layout Definition](./layout-definition.md#json-layouts), an [HTMLElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement), or a [parse5 HTML element](https://github.com/inikulin/parse5). If it is an HTMLElement, it must be a `<single-spa-router>` element or a `<template>` that contains a single-spa-router element.
-- `layoutData` (optional): Layout data is an optionally provided object that defines [props](./layout-definition.md#props) and [loaders](./layout-definition.md#props) for [HTML Layouts](./layout-definition.md#html-layouts). You can omit it if using a [JSON Layout](./layout-definition.md#json-layout) or if you do not need to define props or loaders in your HTML Layout. The layoutData object should have top level properties `props` and `loaders` that are each objects. Each of those objects' keys is the name of a prop or loader and its corresponding value.
+- `routesConfig` (required): Routes config is a [JSON Layout Definition](/docs/layout-definition/#json-layouts), an [HTMLElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement), or a [parse5 HTML element](https://github.com/inikulin/parse5). If it is an HTMLElement, it must be a `<single-spa-router>` element or a `<template>` that contains a single-spa-router element.
+- `layoutData` (optional): Layout data is an optionally provided object that defines [props](/docs/layout-definition/#props) and [loaders](/docs/layout-definition/#props) for [HTML Layouts](/docs/layout-definition/#html-layouts). You can omit it if using a [JSON Layout](/docs/layout-definition/#json-layout) or if you do not need to define props or loaders in your HTML Layout. The layoutData object should have top level properties `props` and `loaders` that are each objects. Each of those objects' keys is the name of a prop or loader and its corresponding value.
 
 **Return value**
 
@@ -40,7 +40,7 @@ An opaque `resolvedRoutes` object. It is opaque because you will only use the ob
 
 ## constructApplications
 
-The `constructApplications` API transforms your `resolvedRoutes` into [single-spa application registration objects](./configuration.md#registering-applications). These application registration objects are then used to call [singleSpa.registerApplication()](./api.md#registerapplication).
+The `constructApplications` API transforms your `resolvedRoutes` into [single-spa application registration objects](/docs/configuration#registering-applications). These application registration objects are then used to call [singleSpa.registerApplication()](/docs/api/#registerapplication).
 
 ```js
 import { constructRoutes, constructApplications } from 'single-spa-layout';
@@ -59,11 +59,11 @@ applications.forEach(registerApplication);
 `constructApplications` accepts a single object as an argument, with the following properties:
 
 - `routes` (required): The opaque `resolvedRoutes` object returned from `constructRoutes`.
-- `loadApp` (required): A function that is given an application object and must return a [loading function](./configuration#loading-function-or-application).
+- `loadApp` (required): A function that is given an application object and must return a [loading function](/docs/configuration/#loading-function-or-application).
 
 **Return value**
 
-`constructApplications` returns an array of [single-spa registration objects](./configuration.md#registering-applications).
+`constructApplications` returns an array of [single-spa registration objects](/docs/configuration/#registering-applications).
 
 ## constructLayoutEngine
 
@@ -90,7 +90,7 @@ start();
 `constructLayoutEngine` accepts a single object as an argument, with the following properties:
 
 - `routes` (required): The opaque `resolvedRoutes` object returned from `constructRoutes`.
-- `applications` (required): The array of [application registration objects](./configuration.md#registering-applications) returned from `constructApplications`.
+- `applications` (required): The array of [application registration objects](/docs/configuration/#registering-applications) returned from `constructApplications`.
 - `active` (optional): A boolean that indicates whether the layout engine should start out active or not. Defaults to true.
 
 **Return Value**

--- a/website/versioned_docs/version-5.x/layout-definition.md
+++ b/website/versioned_docs/version-5.x/layout-definition.md
@@ -4,7 +4,7 @@ title: Layout Definition
 sidebar_label: Layout Definition
 ---
 
-A layout is a combination of HTMLElements, routes, and [single-spa applications](./building-applications). Layout is defined statically in your [root config](./configuration) to handle your top level routes and dom elements. Single-spa-layout should not be used outside of the root config; instead, a UI framework (React, Angular, Vue) should handle layouts within the applications.
+A layout is a combination of HTMLElements, routes, and [single-spa applications](/docs/building-applications/). Layout is defined statically in your [root config](/docs/configuration/) to handle your top level routes and dom elements. Single-spa-layout should not be used outside of the root config; instead, a UI framework (React, Angular, Vue) should handle layouts within the applications.
 
 You may define layouts as either HTML templates or JSON objects. Defining in JSON is supported for organizations who prefer storing their layout definitions in a database instead of code. Both HTML and JSON layouts have the same feature set. However, storing layouts in code is generally preferred and encouraged by default. If you're just getting started with single-spa-layout, we encourage using an HTML template.
 
@@ -141,13 +141,13 @@ The `route` element is used to control which applications and dom elements are s
 Routes must either have a path or be a default route.
 
 - `routes` (required): An array of children elements that will be displayed when the route is active
-- `path` (optional): A string path that will be matched against the browser's URL. The path is relative to its parent route (or the base URL). Leading and trailing `/` characters are unnecessary and are automatically applied. Paths may contain "dynamic segments" by using the `:` character (`"clients/:id/reports"`). Single-spa-layout uses single-spa's [`pathToActiveWhen` function](./api#pathtoactivewhen) to convert the path string to an [activity function](./configuration#activity-function).
+- `path` (optional): A string path that will be matched against the browser's URL. The path is relative to its parent route (or the base URL). Leading and trailing `/` characters are unnecessary and are automatically applied. Paths may contain "dynamic segments" by using the `:` character (`"clients/:id/reports"`). Single-spa-layout uses single-spa's [`pathToActiveWhen` function](/docs/api/#pathtoactivewhen) to convert the path string to an [activity function](/docs/configuration/#activity-function).
 - `default` (optional): A boolean that determines whether this route will match all remaining URLs that have not been defined by sibling routes. This is useful for 404 Not Found pages. A sibling route is defined as any route with the same nearest-parent-route.
-- `props`: An object of [single-spa custom props](./building-applications#lifecycle-props) that will be provided to the application when it is mounted. Note that these can be defined differently for the same application on different routes. You can read more about defining props within your HTML [in the docs below](#props).
+- `props`: An object of [single-spa custom props](/docs/building-applications/#lifecycle-props) that will be provided to the application when it is mounted. Note that these can be defined differently for the same application on different routes. You can read more about defining props within your HTML [in the docs below](#props).
 
 ### `<application>`
 
-The `application` element is used to render a [single-spa application](./building-applications). Applications may be contained within route elements, or may exist at the top level as applications that will always be rendered. A container HTMLElement will be created by single-spa-layout when the application is rendered. The container HTMLElement is created with an `id` attribute of `single-spa-application:appName` such that your [framework helpers](./ecosystem.md) will automatically use it when [mounting](./building-applications#mount) the application.
+The `application` element is used to render a [single-spa application](/docs/building-applications/). Applications may be contained within route elements, or may exist at the top level as applications that will always be rendered. A container HTMLElement will be created by single-spa-layout when the application is rendered. The container HTMLElement is created with an `id` attribute of `single-spa-application:appName` such that your [framework helpers](/docs/ecosystem/) will automatically use it when [mounting](/docs/building-applications/#mount) the application.
 
 The same application may appear multiple times in your layout, under different routes. However, each application can only be defined once per-route.
 
@@ -197,9 +197,9 @@ const parcelConfig = singleSpaReact({...})
 
 **Attributes**
 
-- `name` (required): The string [application name](./api#configuration-object).
-- `loader` (optional): An HTML string or [single-spa parcel config object](./parcels-overview#parcel-configuration). The loader will be mounted to the DOM while waiting for the application's [loading function](./configuration#loading-function-or-application) to resolve. You can read more about defining loaders [in the docs below](#loading-uis)
-- `props`: An object of [single-spa custom props](./building-applications#lifecycle-props) that will be provided to the application when it is mounted. Note that these can be defined differently for the same application on different routes. You can read more about defining props within your HTML [in the docs below](#props).
+- `name` (required): The string [application name](/docs/api/#configuration-object).
+- `loader` (optional): An HTML string or [single-spa parcel config object](/docs/parcels-overview/#parcel-configuration). The loader will be mounted to the DOM while waiting for the application's [loading function](/docs/configuration/#loading-function-or-application) to resolve. You can read more about defining loaders [in the docs below](#loading-uis)
+- `props`: An object of [single-spa custom props](/docs/building-applications/#lifecycle-props) that will be provided to the application when it is mounted. Note that these can be defined differently for the same application on different routes. You can read more about defining props within your HTML [in the docs below](#props).
 
 ### DOM elements
 
@@ -218,7 +218,7 @@ DOM elements defined within a route will be mounted/unmounted as the route becom
 
 ## Props
 
-[Single-spa custom props](./building-applications#lifecycle-props) may be defined on both `route` and `application` elements. Any route props will be merged together with the application props to create the final props that are passed to [the single-spa lifecycle functions](./building-applications#registered-application-lifecycle).
+[Single-spa custom props](/docs/building-applications/#lifecycle-props) may be defined on both `route` and `application` elements. Any route props will be merged together with the application props to create the final props that are passed to [the single-spa lifecycle functions](/docs/building-applications/#registered-application-lifecycle).
 
 ### JSON
 
@@ -260,9 +260,9 @@ The full API documentation for the `constructRoutes` API explains the `data` obj
 
 ## Loading UIs
 
-It is often desireable to show a loading UI when waiting for an application's code to download and execute. Single-spa-layout allows you to define per-application loaders that will be mounted to the DOM while the application's [loading function](./configuration.md#loading-function-or-application) is pending. It is possible to share the same loading UI for multiple applications.
+It is often desireable to show a loading UI when waiting for an application's code to download and execute. Single-spa-layout allows you to define per-application loaders that will be mounted to the DOM while the application's [loading function](/docs/configuration/#loading-function-or-application) is pending. It is possible to share the same loading UI for multiple applications.
 
-A loading UI is defined as either an HTML string or as a [parcel config object](./parcels-overview/#parcel-configuration). HTML strings are best for static, non-interactive loaders, whereas parcels are best when you want to use a framework (Vue, React, Angular, etc) to dynamically render the loader.
+A loading UI is defined as either an HTML string or as a [parcel config object](/docs/parcels-overview/#parcel-configuration). HTML strings are best for static, non-interactive loaders, whereas parcels are best when you want to use a framework (Vue, React, Angular, etc) to dynamically render the loader.
 
 Defining loaders via javascript objects is straightforward, as they are an object that can contain strings, numbers, booleans, objects, arrays, etc. However, defining complex data types in HTML is not as straightforward, since HTML attributes are always strings. To work around this, single-spa-layout allows you to name your loaders in the HTML, but define their values in javascript.
 

--- a/website/versioned_docs/version-5.x/layout-overview.md
+++ b/website/versioned_docs/version-5.x/layout-overview.md
@@ -17,14 +17,14 @@ The `single-spa-layout` npm package is an optional add-on to single-spa. The lay
 
 The layout engine performs two major tasks:
 
-1. Generate [single-spa registration config](./api#configuration-object) from an HTML Element and/or JSON object.
-1. Listen to [routing events](./api#events) to ensure that all DOM elements are laid out correctly before the single-spa applications are mounted.
+1. Generate [single-spa registration config](/docs/api/#configuration-object) from an HTML Element and/or JSON object.
+1. Listen to [routing events](/docs/api/#events) to ensure that all DOM elements are laid out correctly before the single-spa applications are mounted.
 
 `single-spa-layout` is 3.2kb gzipped (9kb ungzipped).
 
 ## Installation
 
-You only need to install the layout engine into your [root config](./configuration) (not in any other application).
+You only need to install the layout engine into your [root config](/docs/configuration/) (not in any other application).
 
 ```sh
 npm install --save single-spa-layout@beta

--- a/website/versioned_docs/version-5.x/single-spa-config.md
+++ b/website/versioned_docs/version-5.x/single-spa-config.md
@@ -94,7 +94,7 @@ single-spa will call each application's activity function under the following sc
 
 #### Custom props
 
-The optional fourth argument to `registerApplication` is [custom props](./building-applications#custom-props) that are passed to the application's single-spa lifecycle functions. The custom props may be either an object or a function that returns an object. Custom prop functions are called with the application name and current `window.location` as arguments.
+The optional fourth argument to `registerApplication` is [custom props](/docs/building-applications/#custom-props) that are passed to the application's single-spa lifecycle functions. The custom props may be either an object or a function that returns an object. Custom prop functions are called with the application name and current `window.location` as arguments.
 
 ### Using configuration object
 
@@ -157,7 +157,7 @@ prefix. Examples:
 
 #### config.customProps
 
-The optional `customProps` property provides [custom props](./building-applications#custom-props) that are passed to the application's single-spa lifecycle functions. The custom props may be either an object or a function that returns an object. Custom prop functions are called with the application name and current `window.location` as arguments.
+The optional `customProps` property provides [custom props](/docs/building-applications/#custom-props) that are passed to the application's single-spa lifecycle functions. The custom props may be either an object or a function that returns an object. Custom prop functions are called with the application name and current `window.location` as arguments.
 
 ## Calling singleSpa.start()
 The [`start()` api](api.md#start) **must** be called by your single spa config in order for


### PR DESCRIPTION
See related https://github.com/single-spa/single-spa.js.org/issues/297, https://github.com/single-spa/single-spa.js.org/pull/299, and https://github.com/single-spa/single-spa.js.org/issues/297.

The root of the problem here is that Docusaurus v2 doesn't really work on Github pages. You have to have a trailing slash in links for it to work. And relative links do not work as advertised. Hard coding to `/docs/` breaks how links are supposed to be relative to the version of the documentation. But we need this working for the single-spa@5 branch and I don't have the desire to figure out how to switch off of github pages today.