### PR TITLE
Fixed typo in parcels overview

### DIFF
--- a/website/versioned_docs/version-4.x/parcels-overview.md
+++ b/website/versioned_docs/version-4.x/parcels-overview.md
@@ -149,7 +149,7 @@ function unmount(props) {
 ### Update (optional)
 
 The update lifecycle function will be called whenever the user of the parcel calls `parcel.update()`.
-Single this lifecycle is optional, the user of a parcel needs to check whether the parcel has implemented the update lifecycle before attempting to make the call.
+Since this lifecycle is optional, the user of a parcel needs to check whether the parcel has implemented the update lifecycle before attempting to make the call.
 
 ## Example use cases
 

--- a/website/versioned_docs/version-5.x/parcels-overview.md
+++ b/website/versioned_docs/version-5.x/parcels-overview.md
@@ -153,7 +153,7 @@ function unmount(props) {
 ### Update (optional)
 
 The update lifecycle function will be called whenever the user of the parcel calls `parcel.update()`.
-Single this lifecycle is optional, the user of a parcel needs to check whether the parcel has implemented the update lifecycle before attempting to make the call.
+Since this lifecycle is optional, the user of a parcel needs to check whether the parcel has implemented the update lifecycle before attempting to make the call.
 
 ## Example use cases
 


### PR DESCRIPTION
Change 'single' to 'since' in the Update lifecycle explanation.