### PR TITLE
Updating single-spa-layout now that it's out of beta.

### DIFF
--- a/website/versioned_docs/version-5.x/layout-overview.md
+++ b/website/versioned_docs/version-5.x/layout-overview.md
@@ -34,15 +34,11 @@ On the server, the layout engine performs two tasks:
 You only need to install the layout engine into your [root config](/docs/configuration/) (not in any other application).
 
 ```sh
-npm install --save single-spa-layout@beta
+npm install --save single-spa-layout
 
 # or
-yarn add single-spa-layout@beta
+yarn add single-spa-layout
 ```
-
-### Project status
-
-`single-spa-layout` is new and currently released under the `beta` dist-tag on npm. We are gathering feedback and improving the layout engine in preparation for a stable release. Although we do not expect the layout engine to change drastically, we do not recommend using it in a production setting until it is released as stable.
 
 ### Browser / NodeJS support
 

--- a/website/versioned_sidebars/version-5.x-sidebars.json
+++ b/website/versioned_sidebars/version-5.x-sidebars.json
@@ -98,7 +98,7 @@
     },
     {
       "type": "category",
-      "label": "Layout Engine (Beta)",
+      "label": "Layout Engine",
       "items": [
         {
           "type": "doc",
@@ -210,7 +210,7 @@
     },
     {
       "type": "category",
-      "label": "Server Side Rendering (Beta)",
+      "label": "Server Side Rendering (New)",
       "items": [
         {
           "type": "doc",


### PR DESCRIPTION
single-spa-layout@1.0.1 is released, which is no longer under the `beta` dist-tag. See https://github.com/single-spa/single-spa-layout/releases/tag/v1.0.1