### PR TITLE
Deployment previews on pull requests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,9 +27,10 @@ jobs:
             cd website 
             yarn install --frozen-lockfile
             yarn build
-      - run:
-          name: Ping FeaturePeek
-          command: bash <(curl -s https://peek.run/ci)
+            if [ "$CIRCLE_BRANCH" != "master" ]; then
+              # Ping FeaturePeek
+              bash <(curl -s https://peek.run/ci)
+            fi
 workflows:
   version: 2
   build_and_deploy:
@@ -45,7 +46,6 @@ workflows:
             branches:
               ignore:
                 - gh-pages
-                - master
       - deploy-website:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,9 @@ jobs:
             cd website 
             yarn install --frozen-lockfile
             yarn build
+      - run:
+          name: Ping FeaturePeek
+          command: bash <(curl -s https://peek.run/ci)
 workflows:
   version: 2
   build_and_deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ workflows:
             branches:
               ignore:
                 - gh-pages
+                - master
       - deploy-website:
           filters:
             branches:

--- a/peek.yml
+++ b/peek.yml
@@ -1,0 +1,5 @@
+version: 2
+main:
+  type: static
+  path: website/build
+  spa: false


### PR DESCRIPTION
I think this repo would benefit in having deployment previews on every pull request, that way we can generate an automatic build of the website per PR rather than having to checkout branches locally to review/verify changes.

These are the changes needed to integrate w/ [FeaturePeek](https://featurepeek.com), a deployment preview provider. If the GitHub App is installed (for webhooks), then every subsequent PR will have its own deployment preview.