### PR TITLE
Fix link of custom props

### DIFF
--- a/website/versioned_docs/version-5.x/ecosystem-vue.md
+++ b/website/versioned_docs/version-5.x/ecosystem-vue.md
@@ -130,7 +130,7 @@ export const unmount = vueLifecycles.unmount;
 
 ## Custom props
 
-[Single-spa custom props](/docs/building-applications/#lifecycle-props) can be passed to your root component like so:
+[Single-spa custom props](/docs/building-applications/#custom-props) can be passed to your root component like so:
 
 ```js
 // main.js


### PR DESCRIPTION
Make it the same with https://single-spa.js.org/docs/ecosystem-vue#custom-props-1.

And in fact, the website has a typo but accessible link, https://single-spa.js.org/docs/building-applications/#lifecyle-props.