### PR TITLE
docs(setup): clarify recommendation for shared-deps

### DIFF
--- a/website/versioned_docs/version-5.x/recommended-setup.md
+++ b/website/versioned_docs/version-5.x/recommended-setup.md
@@ -34,7 +34,7 @@ is via [webpack externals](https://webpack.js.org/configuration/externals/#root)
 Here are our recommendations:
 
 1. Each single-spa application should be an in-browser Javascript module.
-2. Large shared dependencies (ie, the react, vue, or angular libraries) should each be in-browser modules.
+2. Each large shared-dependency (ie, the react, vue, or angular libraries) should also be an in-browser module.
 3. Everything else should be a build-time module.
 
 ## Import Maps


### PR DESCRIPTION
previous statement could be mis-construed, the edit attempts to make it clear that there's only one type of in-browser module being talked about.

key change is the inclusion of the word `also`, everything else was just supporting that change.