### PR TITLE
Remove project status warning in angular docs

### DIFF
--- a/website/versioned_docs/version-5.x/ecosystem-angular.md
+++ b/website/versioned_docs/version-5.x/ecosystem-angular.md
@@ -4,6 +4,10 @@ title: single-spa-angular
 sidebar_label: Angular
 ---
 
+### Project Status
+
+The single-spa-angular project is overseen by the single-spa core team, but largely maintained by the community using it. This is because the single-spa core team is stronger in other frameworks and often doesn't have the expertise to fix bugs in a timely manner. There are a few community members who help us actively maintain the project, which we greatly appreciate. If you have Angular experience, we'd appreciate your help in maintaining the repo. To do so, set up notifications by watching the single-spa-angular Github repository. Also, please join the `#maintainers` and `#angular` channels in Slack.
+
 ## Introduction
 
 [single-spa-angular](https://github.com/single-spa/single-spa-angular/) is a library for creating Angular microfrontends.
@@ -17,10 +21,6 @@ The documentation here is extensive, so use the sidenav on the right. 👉👉�
 ### Community
 
 Join the `#angular` channel in [single-spa's slack workspace](https://join.slack.com/t/single-spa/shared_invite/zt-l2iljnpv-pW_o92mMpMR8RWfIOI6pTQ).
-
-### Project Status
-
-The single-spa-angular project is overseen by the single-spa core team, but largely maintained by the community using it. This is because the single-spa core team is stronger in other frameworks and often doesn't have the expertise to fix bugs in a timely manner. If you have Angular experience, we'd appreciate your help in maintaining the repo. To do so, set up notifications by watching the single-spa-angular Github repository. Also, please join the `#maintainers` and `#angular` channels in Slack.
 
 ### Demo
 

--- a/website/versioned_docs/version-5.x/ecosystem-angular.md
+++ b/website/versioned_docs/version-5.x/ecosystem-angular.md
@@ -4,10 +4,6 @@ title: single-spa-angular
 sidebar_label: Angular
 ---
 
-## Project Status
-
-This project needs new maintainers. The single-spa core team does not have the Angular expertise needed to continously support all versions of Angular, as none of us use single-spa-angular in any of our serious projects. We could use help keeping up with the six month release cadence of Angular, diagnosing problems in the issue queues, and providing support in the single-spa Slack workspace. Angular is the framework that is hardest to support in the single-spa ecosystem, and we rely on the community to help us with it. If you have interest in helping with the maintenance of this project, please let us know!
-
 ## Introduction
 
 [single-spa-angular](https://github.com/single-spa/single-spa-angular/) is a library for creating Angular microfrontends.

--- a/website/versioned_docs/version-5.x/ecosystem-vue.md
+++ b/website/versioned_docs/version-5.x/ecosystem-vue.md
@@ -343,3 +343,30 @@ export default {
 }
 </script>
 ```
+
+## Webpack Public Path
+
+[vue-cli-plugin-single-spa](https://github.com/single-spa/vue-cli-plugin-single-spa) sets the [webpack public path](https://webpack.js.org/guides/public-path/#root) via [SystemJSPublicPathWebpackPlugin](https://github.com/joeldenning/systemjs-webpack-interop). By default, the public path is set to match the following output directory structure:
+
+```sh
+dist/
+  js/
+    app.js
+  css/
+    main.css
+```
+
+With this directory structure (which is the Vue CLI default), the public path should **not** include the `js` folder. This is accomplished by settings [`rootDirectoryLevel`](https://github.com/joeldenning/systemjs-webpack-interop#as-a-webpack-plugin) to be `2`. If this doesn't match your directory structure or setup, you can change the `rootDirectoryLevel` with the following code in your vue.config.js or webpack.config.js:
+
+```js
+// vue.config.js
+// In vue.config.js
+module.exports = {
+  chainWebpack(config) {
+    config.plugin('SystemJSPublicPathWebpackPlugin').tap((args) => {
+      args[0].rootDirectoryLevel = 1;
+      return args;
+    });
+  }
+}
+```

--- a/website/versioned_docs/version-5.x/ecosystem-vue.md
+++ b/website/versioned_docs/version-5.x/ecosystem-vue.md
@@ -385,18 +385,10 @@ dist/
     main.css
 ```
 
-<<<<<<< HEAD
-With this directory structure (which is the Vue CLI default), the public path should **not** include the `js` folder. This is accomplished by settings [`rootDirectoryLevel`](https://github.com/joeldenning/systemjs-webpack-interop#as-a-webpack-plugin) to be `2`. If this doesn't match your directory structure or setup, you can change the `rootDirectoryLevel` with the following code in your vue.config.js or webpack.config.js:
-
-```js
-// vue.config.js
-// In vue.config.js
-=======
 With this directory structure (which is the Vue CLI default), the public path should **not** include the `js` folder. This is accomplished by setting [`rootDirectoryLevel`](https://github.com/joeldenning/systemjs-webpack-interop#as-a-webpack-plugin) to be `2`. If this doesn't match your directory structure or setup, you can change the `rootDirectoryLevel` with the following code in your vue.config.js or webpack.config.js:
 
 ```js
 // vue.config.js
->>>>>>> 5866e530e3e90761fd6d6e96efabccaae21bee8d
 module.exports = {
   chainWebpack(config) {
     config.plugin('SystemJSPublicPathWebpackPlugin').tap((args) => {


### PR DESCRIPTION
See https://single-spa.slack.com/archives/CGETM8T5X/p1612532310102400. Since we added this notice, arturo and danil have stepped into the role of maintainers.