### PR TITLE
Update module-types.md

### DIFF
--- a/website/versioned_docs/version-5.x/module-types.md
+++ b/website/versioned_docs/version-5.x/module-types.md
@@ -66,9 +66,9 @@ For example: Authorization. How does each application know which user is logged 
 Using the utility module pattern would allow you to create one module that implements the authorization logic. This module would export any needed methods, and then your other single-spa applications could use those authorization methods by importing them.
 This approach also works well for data [fetching](/docs/recommended-setup#api-data).
 
-### Examples of Utility MFEs
+### Examples of Utility Microfrontends
 
-The following are commonly implemented as a Utility MFE:
+The following are commonly implemented as a Utility Microfrontend:
 
 - Notification service
 - Styleguide/component library


### PR DESCRIPTION
As a person new to Microfrontend, it was awkward for me to have to shift mid-article from using the term Microfrontend to the acronym MFE. My personal opinion is that the acronym should be either introduced early in the article with an explanation (could be as simple as putting the acronym next to the term `Microfrontend (MFE)`) or not used in this article.