### PR TITLE
add additional examples to angular parcel

### DIFF
--- a/node_modules/.yarn-integrity
+++ b/node_modules/.yarn-integrity
@@ -1,0 +1,10 @@
+{
+  "systemParams": "darwin-x64-93",
+  "modulesFolders": [],
+  "flags": [],
+  "linkedModules": [],
+  "topLevelPatterns": [],
+  "lockfileEntries": {},
+  "files": [],
+  "artifacts": {}
+}

--- a/website/versioned_docs/version-5.x/ecosystem-angular.md
+++ b/website/versioned_docs/version-5.x/ecosystem-angular.md
@@ -939,7 +939,7 @@ export const config = singleSpaReact({
 ### Loading External Components Asynchronously
 
 If your code is part of an import map and you include a global reference to
-systemjs, you can dynamically set the as an async function. 
+systemjs, you can dynamically import the code using an `async` method.
 
 For example, if your import map includes the `ReactComponent`.
 
@@ -952,7 +952,7 @@ For example, if your import map includes the `ReactComponent`.
 ```
 
 You can dynamically load the component by setting the `config` as an
-asynchronous function that fetches the component.
+asynchronous method that fetches the component.
 
 Since some versions of webpack use SystemJS under the hood, you'll need to
 reference the global version.

--- a/website/versioned_docs/version-5.x/ecosystem-angular.md
+++ b/website/versioned_docs/version-5.x/ecosystem-angular.md
@@ -936,6 +936,101 @@ export const config = singleSpaReact({
 });
 ```
 
+### Loading External Components Asynchronously
+
+If your code is part of an import map and you include a global reference to
+systemjs, you can dynamically set the as an async function. 
+
+For example, if your import map includes the `ReactComponent`.
+
+```javascript
+{
+  imports: {
+    "@org/react-component": '/org-react-component.js'
+  }
+}
+```
+
+You can dynamically load the component by setting the `config` as an
+asynchronous function that fetches the component.
+
+Since some versions of webpack use SystemJS under the hood, you'll need to
+reference the global version.
+
+```ts
+// Inside of src/app/app.component.ts
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { mountRootParcel } from 'single-spa';
+
+@Component({
+  selector: 'app-root',
+  template:
+    '<parcel [config]="config" [mountParcel]="mountRootParcel"></parcel>',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AppComponent {
+  async config() {
+    return window.System.import('@org/react-component')
+  }
+  mountRootParcel = mountRootParcel;
+}
+```
+
+### Passing Custom Props
+
+You can pass any custom props to the parcel by passing an object of props using
+the `customProps` attribute.
+
+If you have a custom click event in your React component:
+
+```tsx
+// Inside of src/app/ReactWidget/ReactWidget.tsx
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import singleSpaReact from 'single-spa-react';
+
+const ReactWidget = ({ handleClick }) => <button onClick={handleClick}>Click Me!</button>;
+
+export const config = singleSpaReact({
+  React,
+  ReactDOM,
+  rootComponent: ReactWidget,
+});
+```
+
+You can pass a function as a custom prop. Remember that the context changes when
+you pass in a function, so you may need to use an [arrow
+function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions#call_apply_and_bind)
+to preserve the original Angular context.
+
+```ts
+// Inside of src/app/app.component.ts
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { mountRootParcel } from 'single-spa';
+
+import { config } from './ReactWidget/ReactWidget';
+
+@Component({
+  selector: 'app-root',
+  template:
+    '<parcel [config]="config" [customProps]="parcelProps" [mountParcel]="mountRootParcel"></parcel>',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AppComponent {
+  config = config;
+  mountRootParcel = mountRootParcel;
+
+  handleClick = () => {
+    alert('Hello World');
+  }
+
+  parcelProps = {
+    handleClick = this.handleClick
+  }
+}
+```
+
+
 ## Zone-less applications
 
 :::info

--- a/website/versioned_docs/version-5.x/ecosystem-angular.md
+++ b/website/versioned_docs/version-5.x/ecosystem-angular.md
@@ -981,7 +981,7 @@ export class AppComponent {
 You can pass any custom props to the parcel by passing an object of props using
 the `customProps` attribute.
 
-If you have a custom click event in your React component:
+For example, if you're rendering a React parcel from an Angular component, you can pass a click handler from Angular into the React parcel:
 
 ```tsx
 // Inside of src/app/ReactWidget/ReactWidget.tsx
@@ -991,17 +991,13 @@ import singleSpaReact from 'single-spa-react';
 
 const ReactWidget = ({ handleClick }) => <button onClick={handleClick}>Click Me!</button>;
 
-export const config = singleSpaReact({
+export const parcelConfig = singleSpaReact({
   React,
   ReactDOM,
   rootComponent: ReactWidget,
 });
 ```
-
-You can pass a function as a custom prop. Remember that the context changes when
-you pass in a function, so you may need to use an [arrow
-function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions#call_apply_and_bind)
-to preserve the original Angular context.
+You can pass a function (or any other value) as a custom prop. To ensure that the functions you pass to the parcel are bound with the correct javascript context, use the `handleClick = () => {` syntax when defining your functions.
 
 ```ts
 // Inside of src/app/app.component.ts


### PR DESCRIPTION
Hello, I added some additional examples to the angular parcel documentation.

1) Importing an application that is defined on an import map.

<img width="1654" alt="Screen Shot 2021-09-30 at 9 55 40 AM" src="https://user-images.githubusercontent.com/2388943/135479536-20e661b5-94c2-4538-aba5-2a246e96f05a.png">

2) Passing custom props to the parcel.

<img width="1675" alt="Screen Shot 2021-09-30 at 9 53 53 AM" src="https://user-images.githubusercontent.com/2388943/135479249-7eff7c9f-94ee-403b-b828-f675fb8bc267.png">

Let me know what you think and if you need any additional details.
