### PR TITLE
[angular-ecosystem] add how to correct angular i18n error in polyfills part

### DIFF
--- a/website/versioned_docs/version-5.x/ecosystem-angular.md
+++ b/website/versioned_docs/version-5.x/ecosystem-angular.md
@@ -773,6 +773,17 @@ If you're looking for a quick one-liner, try adding this line near the top of yo
 <script src="https://unpkg.com/core-js-bundle/minified.js"></script>
 ```
 
+To correct the error `It looks like your application or one of its dependencies is using i18n`.
+
+Install `@angular/localize` in your root-config module
+```sh
+npm i @angular/localize
+```
+Add following import to your root-config.js
+```ts
+import "@angular/localize/init";
+```
+
 ### Internet Explorer
 
 If you need to support IE11 or older, do the following:


### PR DESCRIPTION
Hi,
I recently faced the follwing error. 
<img width="466" alt="Error_i18n" src="https://user-images.githubusercontent.com/10134100/147296256-42f391a0-e54c-4e3c-885b-6fa128412af7.png">
For my case, it was caused by one of my MF using datepicker and paginator of ng-bootstrap which use i18n.
Normaly, we can import `@angular/localize/init` to the polyfills of angular application to correct this error. 

As polyfills in angular MF application will not be loaded automatically, the way I found is to install `@angular/localize` to root-config module and import `@angular/localize/init` to the root-config.js.

So I would like to complete polyfillls part with this correction if anyone else will face the same error.
Thanks