### PR TITLE
New version of docusaurus requires upgraded node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   deploy-website:
     docker:
       # specify the version you desire here
-      - image: circleci/node:12.13.1
+      - image: circleci/node:16
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
   build-website:
     docker:
       # specify the version you desire here
-      - image: circleci/node:12.13.1
+      - image: circleci/node:16
     steps:
       - checkout
       - run:


### PR DESCRIPTION
See #509. The new version of docusaurus requires at least node 14