### PR TITLE
Try fixing deploy by using new Github token

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,12 +9,12 @@ jobs:
       - run:
           name: Deploying to GitHub Pages
           command: |
-            git config --global user.email "frehner@users.noreply.github.com"
-            git config --global user.name "CircleCI on behalf of Anthony Frehner"
+            git config --global user.email "joeldenning@users.noreply.github.com"
+            git config --global user.name "CircleCI on behalf of Joel Denning"
             echo "machine github.com login frehner password $GITHUB_TOKEN" > ~/.netrc
             cd website
             yarn install --frozen-lockfile
-            GIT_USER=frehner yarn deploy
+            GIT_USER=joeldenning yarn deploy
   build-website:
     docker:
       # specify the version you desire here


### PR DESCRIPTION
See https://app.circleci.com/pipelines/github/single-spa/single-spa.js.org/905/workflows/28cb69f8-108d-40c7-9aa6-4809e4ae2bd3/jobs/1798 where the deploys started failing. Our old token expired I think