### PR TITLE
fix: typo in building-applications

### DIFF
--- a/website/src/components/Errors/InvalidLifecycle.js
+++ b/website/src/components/Errors/InvalidLifecycle.js
@@ -40,7 +40,7 @@ export default function InvalidLifecycle(props) {
       </div>
       <h2>Explanation:</h2>
       <p>
-        The <a href={props.isParcel ? 'http://localhost:3000/docs/parcels-api/#parcel-object' : 'https://single-spa.js.org/docs/building-applications/#lifecyle-props'}>{props.lifecycleName} lifecycle function</a> must be a function or array of functions that return a promise.
+        The <a href={props.isParcel ? 'http://localhost:3000/docs/parcels-api/#parcel-object' : 'https://single-spa.js.org/docs/building-applications/#lifecycle-props'}>{props.lifecycleName} lifecycle function</a> must be a function or array of functions that return a promise.
       </p>
     </>
   )

--- a/website/versioned_docs/version-4.x/parcels-overview.md
+++ b/website/versioned_docs/version-4.x/parcels-overview.md
@@ -197,7 +197,7 @@ In general we suggest using the application-aware `mountParcel` API. `mountParce
 
 ### How do I get the `mountParcel` API?
 
-In order to keep the function contextually bound to an application it is provided to the application as a [lifecycle prop](/docs/building-applications/#lifecyle-props). You will need to store and manage that function yourself in your application.
+In order to keep the function contextually bound to an application it is provided to the application as a [lifecycle prop](/docs/building-applications/#lifecycle-props). You will need to store and manage that function yourself in your application.
 
 Example of storing the application specific `mountParcel` API:
 

--- a/website/versioned_docs/version-5.x/building-applications.md
+++ b/website/versioned_docs/version-5.x/building-applications.md
@@ -29,7 +29,7 @@ Notes:
 Framework-specific helper libraries exist in the [single-spa ecosystem](ecosystem.md) to implement these required lifecycle methods. This documentation is helpful for understanding what those helpers are doing, or for implementing your own.
 :::
 
-## Lifecyle props
+## Lifecycle props
 
 Lifecycle functions are called with a `props` argument, which is an object with some guaranteed information and additional custom information.
 

--- a/website/versioned_docs/version-5.x/ecosystem-vue.md
+++ b/website/versioned_docs/version-5.x/ecosystem-vue.md
@@ -113,7 +113,7 @@ const vueLifecycles = singleSpaVue({
     render() {
       return h(App, {
         // single-spa props are available on the "this" object. Forward them to your component as needed.
-        // https://single-spa.js.org/docs/building-applications#lifecyle-props
+        // https://single-spa.js.org/docs/building-applications#lifecycle-props
         name: this.name,
         mountParcel: this.mountParcel,
         singleSpa: this.singleSpa,
@@ -244,7 +244,7 @@ const vueLifecycles = singleSpaVue({
       return h(App, {
         props: {
           // single-spa props are available on the "this" object. Forward them to your component as needed.
-          // https://single-spa.js.org/docs/building-applications#lifecyle-props
+          // https://single-spa.js.org/docs/building-applications#lifecycle-props
           name: this.name,
           mountParcel: this.mountParcel,
           singleSpa: this.singleSpa,

--- a/website/versioned_docs/version-5.x/parcels-overview.md
+++ b/website/versioned_docs/version-5.x/parcels-overview.md
@@ -209,7 +209,7 @@ In general we suggest using the application-aware `mountParcel` API. `mountParce
 
 ### How do I get the `mountParcel` API?
 
-In order to keep the function contextually bound to an application it is provided to the application as a [lifecycle prop](/docs/building-applications/#lifecyle-props). You will need to store and manage that function yourself in your application.
+In order to keep the function contextually bound to an application it is provided to the application as a [lifecycle prop](/docs/building-applications/#lifecycle-props). You will need to store and manage that function yourself in your application.
 
 Example of storing the application specific `mountParcel` API:
 


### PR DESCRIPTION
In [buildingApplications](https://single-spa.js.org/docs/building-applications) the heading `Lifecyle props` probably has a Typo ;) 
This PR fixes all links (some already had the right version and were broken in the previous version) and the heading itself.

This also requires a Change in [vue-cli-plugin-single-spa](https://github.com/single-spa/vue-cli-plugin-single-spa) since the plugin generates a comment referencing this page. I will create a PR with the change in the repository, but the changes should probably be merged at the same time.

Related issue single-spa/vue-cli-plugin-single-spa#42