### PR TITLE
Fix wrong url of "Edit this page" links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -153,7 +153,7 @@ module.exports = {
         docs: {
           path: 'docs',
           sidebarPath: require.resolve('./sidebars.json'),
-          editUrl: `${repoUrl}/blob/master/website/`,
+          editUrl: `${repoUrl}/blob/master/`,
           // sidebarCollapsible: false,
         },
         theme: {


### PR DESCRIPTION
The "Edit this page" link forwards to `website/versioned_docs/` folder in this repo, which is missing and seems to have been renamed as `versioned_docs/`.