### PR TITLE
Fix HTTP request docs for SSR

### DIFF
--- a/website/versioned_docs/version-5.x/server-side-rendering-overview.md
+++ b/website/versioned_docs/version-5.x/server-side-rendering-overview.md
@@ -210,7 +210,7 @@ http
   .createServer((req, res) => {
     const fetchPromises = {};
 
-    sendLayoutHTTPResponse(serverLayout, {
+    sendLayoutHTTPResponse({
       res,
       serverLayout,
       urlPath: req.path,


### PR DESCRIPTION
`sendLayoutHTTPResponse` only takes one argument, and that's the `RenderOptions` object.