### PR TITLE
docs: Update shared-webpack-configs.md with `return` on React configs

### DIFF
--- a/versioned_docs/version-6.x/shared-webpack-configs.md
+++ b/versioned_docs/version-6.x/shared-webpack-configs.md
@@ -104,6 +104,7 @@ module.exports = (webpackConfigEnv, argv) => {
     standaloneOptions: {},
   });
 
+  return merge(defaultConfig, {
      // modify the webpack config however you'd like to by adding to this object
   });
 };


### PR DESCRIPTION
On website [inside this section](https://single-spa.js.org/docs/shared-webpack-configs#usage-1) the code block have an invalid syntax. 

It needs to include the `return merge(defaultConfig, { ... })`. 

This PR fixes this code block example.