### PR TITLE
docs: add angularjs example

### DIFF
--- a/versioned_docs/version-6.x/examples.md
+++ b/versioned_docs/version-6.x/examples.md
@@ -46,6 +46,6 @@ sidebar_label: Resources
   - [single-spa-apollo-cleint-auth-with-apollo-federation-backend](https://github.com/hashaneranda/hotel-app) is a single spa frontend example for hotel app with authentication, styled-components, apollo-client for graphql along with apollo federation microservice backend
 - [single-spa-react-angular](https://github.com/nitinreddy3/react-ng-spa-app) a multi-framework example with React and Angular. This app uses routes to render the React and Angular apps.
 - [vite-ts-single-spa-root-config](https://github.com/long-woo/vite-ts-single-spa-root-config): Create a root config example of single-spa using vite and typescript.
-- [single-spa-angularjs-starter](https://github.com/mbarbosasan/single-spa-angularjs-starter): A simple starter for AngularJS with Webpack and Angular 15 with standalone components.
+- [single-spa-angularjs-starter](https://github.com/mbarbosasan/single-spa-angularjs-starter): A simple starter for AngularJS with Webpack, rendering a parcel of Angular 15 with standalone components.
 
 Have your own example or starter repo? [Submit a PR](https://github.com/single-spa/single-spa.js.org/edit/master/website/versioned_docs/version-5.x/examples.md) to add yours to this list.

--- a/versioned_docs/version-6.x/examples.md
+++ b/versioned_docs/version-6.x/examples.md
@@ -46,5 +46,6 @@ sidebar_label: Resources
   - [single-spa-apollo-cleint-auth-with-apollo-federation-backend](https://github.com/hashaneranda/hotel-app) is a single spa frontend example for hotel app with authentication, styled-components, apollo-client for graphql along with apollo federation microservice backend
 - [single-spa-react-angular](https://github.com/nitinreddy3/react-ng-spa-app) a multi-framework example with React and Angular. This app uses routes to render the React and Angular apps.
 - [vite-ts-single-spa-root-config](https://github.com/long-woo/vite-ts-single-spa-root-config): Create a root config example of single-spa using vite and typescript.
+- [single-spa-angularjs-starter](https://github.com/mbarbosasan/single-spa-angularjs-starter): A simple starter for AngularJS with Webpack and Angular 15 with standalone components.
 
 Have your own example or starter repo? [Submit a PR](https://github.com/single-spa/single-spa.js.org/edit/master/website/versioned_docs/version-5.x/examples.md) to add yours to this list.


### PR DESCRIPTION
Hi guys, first of all, sorry if i make some grammar mistakes, english isn't my primary language.

In the past year, i had to update a legacy application with a codebase 10 years old that was using AngularJS, and unfortunately, we can't just throw away all components and rewrite them in new frameworks, we found SingleSPA and Microfrontends and was perfect for what we are searching, but we had some struggle to find content about SingleSPA with AngularJS.

So i would like to give back and have created a simple starter for those who will or are trying to do so, maybe it's not the best configs but certainly will help somebody.