### PR TITLE
Fixed typo in parameter `spaEntryPoints` in ecosystem-vite.md

### DIFF
--- a/versioned_docs/version-6.x/ecosystem-vite.md
+++ b/versioned_docs/version-6.x/ecosystem-vite.md
@@ -85,7 +85,7 @@ export default defineConfig({
     react(),
     vitePluginSingleSpa({
       serverPort: 4101,
-      spaEntryPoint: "src/spa.tsx",
+      spaEntryPoints: "src/spa.tsx",
     }),
   ],
 });


### PR DESCRIPTION
As per `vite-plugin-single-spa` docs: https://github.com/WJSoftware/vite-plugin-single-spa/blob/4a96185b15c61e0aa9399568b793f0e6c687bce6/README.md?plain=1#L248 parameter here should be `spaEntryPoints` (plural) instead of `spaEntryPoint`.