### PR TITLE
feat:  Add configureLogger() API

### DIFF
--- a/src/components/Errors/Codes/42.js
+++ b/src/components/Errors/Codes/42.js
@@ -1,0 +1,39 @@
+import React from "react";
+
+export default function ErrorCode42(props) {
+  return (
+    <>
+      <h1>#42: The given logger does not conform to the ILogger interface</h1>
+      <p>
+        The <code>configureLogger()</code> function was called with an argument that does not
+        conform to the <code>ILogger</code> interface. An <code>ILogger</code> must have the
+        following members: <code>debug()</code>, <code>info()</code>, <code>warn()</code> and
+        <code>error()</code>.
+      </p>
+      <h2>To fix:</h2>
+      <p>
+        There are 3 possible arguments that are acceptable for <code>configureLogger()</code>:
+      </p>
+      <ol>
+        <li>
+          The value <code>null</code>, that silences all log messages coming from single-spa.
+        </li>
+        <li>
+          The <code>console</code> object, which causes single-spa to log all messages directly to the console.
+        </li>
+        <li>
+          A custom implementation that can be used for pretty much anyting:  From selective 
+          silencing of specific errors to forwarding logs to a central logging service.
+        </li>
+      </ol>
+      <h2>Additional references</h2>
+      <p>
+        See{" "}
+        <a href="/docs/api#configurelogger">
+          the API documentation
+        </a>{" "}
+        for information and the details of the <code>ILogger</code> interface.
+      </p>
+    </>
+  );
+}

--- a/versioned_docs/version-6.x/api.md
+++ b/versioned_docs/version-6.x/api.md
@@ -704,6 +704,54 @@ Sets the global configuration for unload timeouts.
 
 `undefined`
 
+---
+
+## configureLogger
+
+```js
+// Silence all logging.
+singleSpa.configureLogger(null);
+
+// Restore console logging (single-spa's default behavior).
+singleSpa.configureLogger(console);
+
+// Custom logger implementation.
+const myLogger = new MyLogger(); // MyLogger must implement ILogger.
+singleSpa.configureLogger(myLogger);
+```
+
+Controls the destination of logged messages.  Use it whenever you want or need to take control 
+over what is being logged and where.  Logging can be silenced, can be restored, or a custom 
+implementation can be provided for the fancier use cases.
+
+<h3>ILogger</h3>
+
+```typescript
+  export interface ILogger {
+    debug(...data: any[]): void;
+    info(...data: any[]): void;
+    warn(...data: any[]): void;
+    error(...data: any[]): void;
+  }
+```
+
+Custom loggers must conform to the `ILogger` interface shown above.  The implementation can do 
+anything it wants with the provided data, but **must never throw** as single-spa does not account 
+for potential errors from custom implementations.
+
+<h3>arguments</h3>
+
+<dl className="args-list">
+	<dt>logger: ILogger | null</dt>
+  <dd>The desired logger object, or <code>null</code> to silence logging.</dd>
+</dl>
+
+<h3>returns</h3>
+
+`undefined`
+
+---
+
 ## Events
 
 single-spa fires Events to the `window` as a way for your code to hook into URL transitions.


### PR DESCRIPTION
The documentation related to the PR about adding the `configureLogger()` function that gives the user the ability to control what single-spa ends up logging to the console.

It contains the documentation for the new function as well as a new minified error.