### PR TITLE
docs: Add missing `parcelError` & commas in ecosystem-vue.md

### DIFF
--- a/versioned_docs/version-6.x/ecosystem-vue.md
+++ b/versioned_docs/version-6.x/ecosystem-vue.md
@@ -267,6 +267,7 @@ To render a parcel config object in Vue, you can use single-spa-vue's `Parcel` c
   <Parcel
     v-on:parcelMounted="parcelMounted()"
     v-on:parcelUpdated="parcelUpdated()"
+    v-on:parcelError="err => parcelError(err)"
     :config="parcelConfig"
     :mountParcel="mountParcel"
     :wrapWith="wrapWith"
@@ -328,14 +329,14 @@ export default {
         The wrapWith string determines what kind of dom element will be provided to the parcel.
         Defaults to 'div'
       */
-      wrapWith: 'div'
+      wrapWith: 'div',
 
       /*
         wrapClass (string, optional)
 
         The wrapClass string is applied to as the CSS class for the dom element that is provided to the parcel
       */
-      wrapClass: "bg-red"
+      wrapClass: "bg-red",
 
       /*
         wrapStyle (object, optional)
@@ -360,6 +361,9 @@ export default {
     },
     parcelUpdated() {
       console.log("parcel updated");
+    },
+    parcelError(err) {
+      console.error(err);
     }
   }
 }


### PR DESCRIPTION
Hey, I’m using `single-spa-vue/parcel` to build my application, and I encountered cases where I needed to handle errors when mounting a parcel that failed. I checked the docs but couldn’t find anything related.

Looking into `single-spa-react`, I noticed that the Parcel configuration includes a `handleError` function. So, I dug into the `single-spa-vue/parcel` code and found that we do emit errors in `parcel.js`:
[Parcel.js (Line 55)](https://github.com/single-spa/single-spa-vue/blob/main/src/parcel.js#L55).

I tested using this API, and everything worked fine. So, I’d like to add this missing information here.