### PR TITLE
Fix links in error code docs

### DIFF
--- a/src/components/Errors/Codes/1.js
+++ b/src/components/Errors/Codes/1.js
@@ -24,7 +24,7 @@ export default function ErrorCode1() {
         The single-spa start() API exists to give you fine-grained control over
         performance. In the majority of use cases, you should call
         singleSpa.start() immediately after{" "}
-        <a href="http://localhost:3000/docs/api#registerapplication">
+        <a href="/docs/api#registerapplication">
           registering your applications
         </a>
         . It was designed for situations where you want to start downloading a

--- a/src/components/Errors/Codes/2.js
+++ b/src/components/Errors/Codes/2.js
@@ -39,7 +39,7 @@ export default function ErrorCode2() {
         The single-spa start() API exists to give you fine-grained control over
         performance. In the majority of use cases, you should call
         singleSpa.start() immediately after{" "}
-        <a href="http://localhost:3000/docs/api#registerapplication">
+        <a href="/docs/api#registerapplication">
           registering your applications
         </a>
         . It was designed for situations where you want to start downloading a

--- a/src/pages/error/index.js
+++ b/src/pages/error/index.js
@@ -40,7 +40,7 @@ function Error(props) {
           errorCode={params.get("code")}
         />
         <a
-          href={`https://github.com/single-spa/single-spa.js.org/edit/master/website/src/components/Errors/Codes/${params.get(
+          href={`https://github.com/single-spa/single-spa.js.org/edit/master/src/components/Errors/Codes/${params.get(
             "code",
           )}.js`}
         >


### PR DESCRIPTION
This PR aims to fix:

- A URL typo in two of the error code docs
- The base URL for editing the error code docs.